### PR TITLE
[refactor]將二次確認加入退訂/[feat]加入msgstore的狀態管理去重複使用套件

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,8 +2,10 @@
   <div v-if="authStore.isAuthReady">
     <RouterView />
   </div>
-  <div v-else class="w-full h-screen flex items-center justify-center">
-    <p class="text-white">正在載入頁面</p>
+  <div
+    v-else
+    class="w-full h-screen flex items-center justify-center">
+    <div class="loader"></div>
   </div>
 </template>
 
@@ -60,5 +62,23 @@ onIdTokenChanged(auth, async (firebaseUser) => {
   color: white;
   background-color: #131417;
   color: white;
+}
+
+.loader {
+  border: 8px solid #f3f3f3;
+  border-top: 8px solid #38bdf8;
+  border-radius: 50%;
+  width: 56px;
+  height: 56px;
+  animation: spin 1s linear infinite;
+  margin: auto;
+}
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/src/components/ui/ConfirmModal.vue
+++ b/src/components/ui/ConfirmModal.vue
@@ -2,9 +2,10 @@
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
     <div
       class="p-6 rounded-md max-w-sm w-full border-8"
-      :class="styleClasses.container"
-    >
-      <p class="font-bold mb-2 text-lg" v-if="$slots.title">
+      :class="styleClasses.container">
+      <p
+        class="font-bold mb-2 text-lg"
+        v-if="$slots.title">
         <slot name="title" />
       </p>
 
@@ -14,13 +15,15 @@
 
       <div class="flex text-sm justify-start space-x-2">
         <button
+          class="cursor-pointer"
           :disabled="confirming"
           @click="onConfirm"
-          :class="styleClasses.confirm"
-        >
+          :class="styleClasses.confirm">
           {{ confirming ? loadingText : confirmText }}
         </button>
-        <button @click="onCancel" class="bg-cc-13 px-4.5 py-2.5 rounded">
+        <button
+          @click="onCancel"
+          class="bg-cc-13 px-4.5 py-2.5 rounded cursor-pointer hover:bg-cc-14 text-cc-1">
           {{ cancelText }}
         </button>
       </div>

--- a/src/components/ui/ConfirmModal.vue
+++ b/src/components/ui/ConfirmModal.vue
@@ -22,6 +22,7 @@
           {{ confirming ? loadingText : confirmText }}
         </button>
         <button
+          v-if="cancelText"
           @click="onCancel"
           class="bg-cc-13 px-4.5 py-2.5 rounded cursor-pointer hover:bg-cc-14 text-cc-1">
           {{ cancelText }}
@@ -40,7 +41,6 @@ const props = defineProps({
   },
   cancelText: {
     type: String,
-    default: "Cancel",
   },
   confirming: {
     type: Boolean,

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -2,18 +2,18 @@
   <div
     v-show="isMounted"
     class="layout transition-all duration-400 ease-in-out"
-    :style="{ gridTemplateColumns: layoutColumns }"
-  >
+    :style="{ gridTemplateColumns: layoutColumns }">
     <MainSidebar
       class="sidebar"
       v-if="!isCompactScreen"
-      @toggle="toggleSidebar"
-    />
+      @toggle="toggleSidebar" />
 
     <SubHeader class="header" />
 
     <RouterView v-slot="{ Component }">
-      <component :is="Component" class="content" />
+      <component
+        :is="Component"
+        class="content" />
     </RouterView>
 
     <SubFooter class="footer" />
@@ -22,9 +22,22 @@
       v-if="modalStore.showDetailModal"
       :pen-id="modalStore.penId"
       :from="modalStore.from"
-      @close="modalStore.closeModal"
-    />
+      @close="modalStore.closeModal" />
   </div>
+  <ConfirmModal
+    v-if="msg.show"
+    :variant="msg.variant"
+    :confirming="msg.confirming"
+    :loadingText="msg.loadingText"
+    :confirm-text="msg.confirmText"
+    :cancel-text="msg.cancelText"
+    @confirm="msg.close"
+    @cancel="msg.close">
+    <template #title>{{ msg.title }}</template>
+    <template #message
+      ><p>{{ msg.message }}</p></template
+    >
+  </ConfirmModal>
 </template>
 
 <script setup>
@@ -34,7 +47,10 @@ import SubHeader from "@/components/SubHeader.vue";
 import SubFooter from "@/components/SubFooter.vue";
 import MainSidebar from "@/components/MainSidebar.vue";
 import PenDetailModal from "@/components/PenDetails/PenDetailModal.vue";
+import { useMsgStore } from "@/stores/useMsgStore";
+import ConfirmModal from "@/components/ui/ConfirmModal.vue";
 
+const msg = useMsgStore();
 const modalStore = useModalStore();
 const isMounted = ref(false);
 const screenWidth = ref(window.innerWidth);

--- a/src/layouts/ProfileLayout.vue
+++ b/src/layouts/ProfileLayout.vue
@@ -121,18 +121,6 @@
       </div>
     </div>
   </div>
-  <ConfirmModal
-    v-if="showMsgModal"
-    variant="success"
-    :confirm-text="'OK'"
-    :confirming="false"
-    :loadingText="'Processing...'"
-    @confirm="showMsgModal = false">
-    <template #title> Success </template>
-    <template #message>
-      <p>{{ Message }}</p>
-    </template>
-  </ConfirmModal>
 </template>
 
 <script setup>
@@ -140,19 +128,17 @@ import { onMounted, ref, watch } from "vue";
 import { RouterView } from "vue-router";
 import { useRouter, useRoute } from "vue-router";
 import { useAuthStore } from "@/stores/useAuthStore";
+import { useMsgStore } from "@/stores/useMsgStore";
 import api from "@/config/api";
 import FollowBtn from "@/components/FollowBtn.vue";
-import ConfirmModal from "@/components/ui/ConfirmModal.vue";
 
+const msg = useMsgStore();
 const router = useRouter();
 const route = useRoute();
 const userInfo = ref(null);
 const authStore = useAuthStore();
 const userFollowers = ref(0);
 const userFollowings = ref(0);
-const showMsgModal = ref(false);
-const Message = ref("");
-
 const caines = () => {
   router.push(`/${route.params.username}/caines`);
 };
@@ -165,8 +151,11 @@ const Followers = () => {
 
 const productSub = () => {
   if (route.query.subscribed === "true") {
-    showMsgModal.value = true;
-    Message.value = "Successfully subscribed to Pro features!";
+    msg.title = "Success";
+    msg.message = "Successfully subscribed to Pro features!";
+    msg.variant = "success";
+    msg.confirmText = "OK";
+    msg.show = true;
   }
 };
 const countFollowers = async () => {
@@ -228,10 +217,10 @@ const fetchUserInfo = async () => {
 };
 
 onMounted(() => {
-  productSub();
   fetchUserInfo();
   countFollowers();
   countFollowing();
+  productSub();
 });
 
 watch(

--- a/src/layouts/ProfileLayout.vue
+++ b/src/layouts/ProfileLayout.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <div
+    class="content"
+    :class="$attrs.class"
+    v-bind="$attrs">
     <div
       class="pt-4"
       v-if="userInfo">

--- a/src/layouts/ProfileLayout.vue
+++ b/src/layouts/ProfileLayout.vue
@@ -151,11 +151,12 @@ const Followers = () => {
 
 const productSub = () => {
   if (route.query.subscribed === "true") {
-    msg.title = "Success";
-    msg.message = "Successfully subscribed to Pro features!";
-    msg.variant = "success";
-    msg.confirmText = "OK";
-    msg.show = true;
+    msg.open({
+      title: "Success",
+      message: "Successfully subscribed to Pro features!",
+      variant: "success",
+      confirmText: "OK",
+    });
   }
 };
 const countFollowers = async () => {

--- a/src/layouts/ProfileLayout.vue
+++ b/src/layouts/ProfileLayout.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <div class="pt-4" v-if="userInfo">
+    <div
+      class="pt-4"
+      v-if="userInfo">
       <header class="profile-header">
         <div class="md:pt-[110px] md:pb-[75px] relative pt-5 pb-5">
           <div class="text-center text-4xl pb-3">
@@ -17,12 +19,10 @@
         </div>
       </header>
       <div
-        class="min-h-14 bg-black relative flex items-center justify-between p-4"
-      >
+        class="min-h-14 bg-black relative flex items-center justify-between p-4">
         <div class="flex flex-col md:flex-row w-full justify-between">
           <div
-            class="flex gap-4 text-gray-400 justify-center md:justify-start mb-2 md:mb-0 min-h-[24px]"
-          >
+            class="flex gap-4 text-gray-400 justify-center md:justify-start mb-2 md:mb-0 min-h-[24px]">
             <a
               class="hover:text-white"
               v-if="userInfo.profile_link1"
@@ -58,8 +58,7 @@
             >
           </div>
           <div
-            class="flex justify-center md:justify-end items-center gap-4 text-gray-400"
-          >
+            class="flex justify-center md:justify-end items-center gap-4 text-gray-400">
             <a
               :href="`/${route.params.username}/following`"
               class="hover:text-white"
@@ -77,18 +76,15 @@
                 userInfo.username !== authStore.userProfile.username
               "
               :current-user="authStore.userProfile.id"
-              :target-user="userInfo.username"
-            />
+              :target-user="userInfo.username" />
           </div>
         </div>
         <div
-          class="absolute left-4 bottom-26 w-[100px] h-[100px] md:absolute md:left-1/2 md:-translate-x-1/2 md:bottom-0 md:w-[124px] md:h-[124px]"
-        >
+          class="absolute left-4 bottom-26 w-[100px] h-[100px] md:absolute md:left-1/2 md:-translate-x-1/2 md:bottom-0 md:w-[124px] md:h-[124px]">
           <img
             :src="userInfo.profile_image_url || '/default-avatar.png'"
             alt="大頭貼"
-            class="bg-black h-full w-full border-gray-700 border-6"
-          />
+            class="bg-black h-full w-full border-gray-700 border-6" />
         </div>
       </div>
       <div class="text-center py-4">
@@ -100,22 +96,19 @@
           <button
             class="cursor-pointer hover:text-white p-2 flex-shrink-0"
             @click="caines"
-            :class="route.path.includes('caines') ? 'text-white' : ''"
-          >
+            :class="route.path.includes('caines') ? 'text-white' : ''">
             Caines
           </button>
           <button
             class="cursor-pointer hover:text-white p-2 flex-shrink-0"
             @click="Following"
-            :class="route.name === 'Profilefollowing' ? 'text-white' : ''"
-          >
+            :class="route.name === 'Profilefollowing' ? 'text-white' : ''">
             Following
           </button>
           <button
             class="cursor-pointer hover:text-white p-2 flex-shrink-0"
             @click="Followers"
-            :class="route.name === 'Profilefollowers' ? 'text-white' : ''"
-          >
+            :class="route.name === 'Profilefollowers' ? 'text-white' : ''">
             Followers
           </button>
         </div>
@@ -125,6 +118,18 @@
       </div>
     </div>
   </div>
+  <ConfirmModal
+    v-if="showMsgModal"
+    variant="success"
+    :confirm-text="'OK'"
+    :confirming="false"
+    :loadingText="'Processing...'"
+    @confirm="showMsgModal = false">
+    <template #title> Success </template>
+    <template #message>
+      <p>{{ Message }}</p>
+    </template>
+  </ConfirmModal>
 </template>
 
 <script setup>
@@ -134,12 +139,16 @@ import { useRouter, useRoute } from "vue-router";
 import { useAuthStore } from "@/stores/useAuthStore";
 import api from "@/config/api";
 import FollowBtn from "@/components/FollowBtn.vue";
+import ConfirmModal from "@/components/ui/ConfirmModal.vue";
+
 const router = useRouter();
 const route = useRoute();
 const userInfo = ref(null);
 const authStore = useAuthStore();
 const userFollowers = ref(0);
 const userFollowings = ref(0);
+const showMsgModal = ref(false);
+const Message = ref("");
 
 const caines = () => {
   router.push(`/${route.params.username}/caines`);
@@ -153,9 +162,8 @@ const Followers = () => {
 
 const productSub = () => {
   if (route.query.subscribed === "true") {
-    alert("Subscription successful! Thank you for your support 🎉");
-  } else if (route.query.subscribed === "false") {
-    alert("Subscription was cancelled or not completed");
+    showMsgModal.value = true;
+    Message.value = "Successfully subscribed to Pro features!";
   }
 };
 const countFollowers = async () => {

--- a/src/stores/useMsgStore.js
+++ b/src/stores/useMsgStore.js
@@ -1,0 +1,53 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export const useMsgStore = defineStore("modal", () => {
+  const show = ref(false);
+  const title = ref("");
+  const message = ref("");
+  const variant = ref("warning");
+  const confirmText = ref("OK");
+  const cancelText = ref("");
+  const confirming = ref(false);
+  const loadingText = ref("Processing...");
+  const onConfirm = ref(null);
+
+  function open({
+    title: t,
+    message: m,
+    variant: v = "warning",
+    confirmText: c = "OK",
+    cancelText: ct = "",
+    confirming: cg = false,
+    loadingText: lt = "Processing...",
+    onConfirm: oc = null,
+  }) {
+    title.value = t;
+    message.value = m;
+    variant.value = v;
+    confirmText.value = c;
+    cancelText.value = ct;
+    confirming.value = cg;
+    loadingText.value = lt;
+    onConfirm.value = oc;
+    show.value = true;
+  }
+  function close() {
+    show.value = false;
+    if (onConfirm.value) onConfirm.value();
+    onConfirm.value = null;
+  }
+
+  return {
+    show,
+    title,
+    message,
+    variant,
+    confirmText,
+    cancelText,
+    confirming,
+    loadingText,
+    open,
+    close,
+  };
+});

--- a/src/views/Billing.vue
+++ b/src/views/Billing.vue
@@ -123,18 +123,6 @@
       </div>
     </div>
   </div>
-  <ConfirmModal
-    v-if="showErrorModal"
-    variant="warning"
-    :confirm-text="'OK'"
-    :confirming="false"
-    :loadingText="'Processing...'"
-    @confirm="showErrorModal = false">
-    <template #title> Error </template>
-    <template #message>
-      <p>{{ errorMessage }}</p>
-    </template>
-  </ConfirmModal>
 </template>
 
 <script setup>
@@ -143,19 +131,24 @@ import { useAuthStore } from "@/stores/useAuthStore";
 import { useRoute } from "vue-router";
 import api from "@/config/api";
 import ConfirmModal from "@/components/ui/ConfirmModal.vue";
+import { useMsgStore } from "@/stores/useMsgStore";
 
 const authStore = useAuthStore();
 const route = useRoute();
+const msg = useMsgStore();
+
 const showunsubscribeModal = ref(false);
 const confirmName = ref("");
 const subscriptionInfo = ref(null);
-const showErrorModal = ref(false);
-const errorMessage = ref("");
 
 const productSub = () => {
   if (route.query.subscribed === "false") {
-    errorMessage.value = "Failed to create subscription session.";
-    showErrorModal.value = true;
+    msg.open({
+      title: "Error",
+      message: "Failed to create subscription session.",
+      variant: "warning",
+      confirmText: "OK",
+    });
   }
 };
 const checkPendingPayment = async () => {
@@ -163,8 +156,12 @@ const checkPendingPayment = async () => {
     const res = await api.get("/api/stripe/subscription-status");
     subscriptionInfo.value = res.data;
   } catch (error) {
-    errorMessage.value = "Failed to fetch subscription status.";
-    showErrorModal.value = true;
+    msg.open({
+      title: "Error",
+      message: "Failed to fetch subscription status.",
+      variant: "warning",
+      confirmText: "OK",
+    });
     subscriptionInfo.value = null;
   }
 };
@@ -177,11 +174,20 @@ const subscribe = async () => {
     if (res.data.url) {
       window.location.href = res.data.url;
     } else {
-      alert("Failed to create subscription session.");
+      msg.open({
+        title: "Error",
+        message: "Failed to create subscription session.",
+        variant: "warning",
+        confirmText: "OK",
+      });
     }
   } catch (error) {
-    errorMessage.value = "Failed to create subscription session.";
-    showErrorModal.value = true;
+    msg.open({
+      title: "Error",
+      message: "Failed to create subscription session.",
+      variant: "warning",
+      confirmText: "OK",
+    });
   }
 };
 const canConfirmUnsubscribe = computed(() => {
@@ -192,8 +198,12 @@ const unSubscribe = async () => {
     const res = await api.put("/api/stripe/cancel-subscription");
     await checkPendingPayment();
   } catch (error) {
-    errorMessage.value = "Failed to cancel subscription.";
-    showErrorModal.value = true;
+    msg.open({
+      title: "Error",
+      message: "Failed to cancel subscription.",
+      variant: "warning",
+      confirmText: "OK",
+    });
   }
   confirmName.value = "";
 };

--- a/src/views/Billing.vue
+++ b/src/views/Billing.vue
@@ -59,12 +59,34 @@
               {{ subscriptionInfo.current_period_end || "—" }}
             </template>
           </div>
-          <button
+          <div
             v-if="!subscriptionInfo.cancel_at_period_end"
-            @click="unSubscribe"
-            class="mt-6 bg-pink-400 hover:bg-pink-600 text-white font-bold py-2 px-6 rounded shadow-lg transition-colors cursor-pointer shake-on-click">
-            Cancel Subscription
-          </button>
+            class="mt-4">
+            <button
+              @click="showunsubscribeModal = true"
+              class="mt-6 bg-pink-400 hover:bg-pink-600 text-white font-bold py-2 px-6 rounded shadow-lg transition-colors cursor-pointer shake-on-click">
+              Cancel Subscription
+            </button>
+            <ConfirmModal
+              v-if="showunsubscribeModal"
+              @confirm="unSubscribe"
+              @cancel="showunsubscribeModal = false">
+              <template #title>
+                Are you sure you want to cancel your subscription?
+              </template>
+
+              <template #message>
+                <p>
+                  After cancellation, you will continue to enjoy Pro features
+                  until the end of your current billing period.<br />
+                  You can re-subscribe at any time.<br />
+                  <span class="text-red-600 font-bold"
+                    >This action will not delete your data.</span
+                  >
+                </p>
+              </template>
+            </ConfirmModal>
+          </div>
           <div
             v-else
             class="mt-4 text-yellow-700 text-center font-bold">
@@ -81,9 +103,10 @@
 import { ref, onMounted } from "vue";
 import { useAuthStore } from "@/stores/useAuthStore";
 import api from "@/config/api";
+import ConfirmModal from "@/components/ui/ConfirmModal.vue";
 
+const showunsubscribeModal = ref(false);
 const authStore = useAuthStore();
-
 const subscriptionInfo = ref(null);
 
 const checkPendingPayment = async () => {
@@ -94,7 +117,6 @@ const checkPendingPayment = async () => {
     alert("Failed to fetch subscription status.");
     subscriptionInfo.value = null;
   }
-  // 成功的情況不用在這裡判斷，因為會直接跳轉到 return_url
 };
 
 const subscribe = async () => {

--- a/src/views/Billing.vue
+++ b/src/views/Billing.vue
@@ -127,11 +127,9 @@
     v-if="showErrorModal"
     variant="warning"
     :confirm-text="'OK'"
-    :cancelText="'cancel'"
     :confirming="false"
     :loadingText="'Processing...'"
-    @confirm="showErrorModal = false"
-    @cancel="showErrorModal = false">
+    @confirm="showErrorModal = false">
     <template #title> Error </template>
     <template #message>
       <p>{{ errorMessage }}</p>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -89,11 +89,6 @@
                 autocomplete="off"
                 class="w-full py-3 px-4 rounded bg-[#b3b4ba] text-black border-none focus:bg-[white] focus:outline-none focus:ring-2 focus:ring-[#38c172] text-base" />
             </div>
-            <p
-              v-if="error"
-              class="text-red-500 mt-4">
-              {{ error }}
-            </p>
             <button
               type="submit"
               class="w-full py-3 bg-[#38c172] rounded text-[#1e1f26] text-base font-medium cursor-pointer transition hover:bg-[#248C46] hover:text-white">

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -12,27 +12,23 @@
         <div class="flex-1 pr-16 flex flex-col items-end">
           <button
             @click="() => socialSignIn(new GoogleAuthProvider())"
-            class="w-3/4 flex items-center py-3 px-4 mb-4 bg-[#444857] rounded cursor-pointer transition hover:bg-[black]"
-          >
+            class="w-3/4 flex items-center py-3 px-4 mb-4 bg-[#444857] rounded cursor-pointer transition hover:bg-[black]">
             <GoogleIcon class="w-5 h-5 mr-3" />
             Log In with Google
           </button>
           <button
             @click="() => socialSignIn(new GithubAuthProvider())"
-            class="w-3/4 flex items-center py-3 px-4 mb-4 bg-[#444857] rounded cursor-pointer transition hover:bg-[black]"
-          >
+            class="w-3/4 flex items-center py-3 px-4 mb-4 bg-[#444857] rounded cursor-pointer transition hover:bg-[black]">
             <GithubIcon class="w-5 h-5 mr-3" />
             Log In with GitHub
           </button>
 
           <div
             class="w-3/4 rounded overflow-hidden transition"
-            :class="{ 'bg-[#323444]': infoOpen }"
-          >
+            :class="{ 'bg-[#323444]': infoOpen }">
             <div
               class="cursor-pointer font-medium text-base leading-tight px-4 py-2 select-none relative"
-              @click="toggleInfo"
-            >
+              @click="toggleInfo">
               <span
                 class="inline-block text-2xl mr-2 align-middle transition-transform"
                 :class="{ 'rotate-90': infoOpen }"
@@ -45,8 +41,7 @@
               :class="
                 infoOpen ? 'max-h-40 opacity-100 ' : 'max-h-0 opacity-0 py-0'
               "
-              ref="infoContent"
-            >
+              ref="infoContent">
               <p class="leading-tight text-sm">
                 If the email address associated with your social account matches
                 the email address of your CodePen account, you'll be logged in.
@@ -58,45 +53,50 @@
 
         <div class="relative flex items-center justify-center self-stretch w-8">
           <div
-            class="absolute top-0 left-1/2 -translate-x-1/2 w-px h-[41%] bg-[white]"
-          ></div>
+            class="absolute top-0 left-1/2 -translate-x-1/2 w-px h-[41%] bg-[white]"></div>
           <span
             class="absolute w-12 h-[18%] left-1/2 top-[41%] -translate-x-1/2 border-2 border-white text-center flex items-center justify-center rounded-[10px] text-lg leading-[30px] bg-[#1e1f26] text-gray"
             >OR</span
           >
           <div
-            class="absolute left-1/2 -translate-x-1/2 w-px h-[41%] bg-white top-[59%]"
-          ></div>
+            class="absolute left-1/2 -translate-x-1/2 w-px h-[41%] bg-white top-[59%]"></div>
         </div>
 
         <div class="flex-1 flex flex-col px-16 pb-8">
           <form @submit.prevent="login">
             <div class="mb-5">
-              <label for="username" class="block mb-1 text-sm">Email</label>
+              <label
+                for="username"
+                class="block mb-1 text-sm"
+                >Email</label
+              >
               <input
                 v-model="email"
                 id="username"
                 type="text"
-                class="w-full py-3 px-4 rounded bg-[#b3b4ba] text-black border-none focus:bg-[white] focus:outline-none focus:ring-2 focus:ring-[#38c172] text-base"
-              />
+                class="w-full py-3 px-4 rounded bg-[#b3b4ba] text-black border-none focus:bg-[white] focus:outline-none focus:ring-2 focus:ring-[#38c172] text-base" />
             </div>
             <div class="mb-5">
-              <label for="password" class="block mb-1 text-sm">Password</label>
+              <label
+                for="password"
+                class="block mb-1 text-sm"
+                >Password</label
+              >
               <input
                 v-model="password"
                 id="password"
                 type="password"
                 autocomplete="off"
-                class="w-full py-3 px-4 rounded bg-[#b3b4ba] text-black border-none focus:bg-[white] focus:outline-none focus:ring-2 focus:ring-[#38c172] text-base"
-              />
+                class="w-full py-3 px-4 rounded bg-[#b3b4ba] text-black border-none focus:bg-[white] focus:outline-none focus:ring-2 focus:ring-[#38c172] text-base" />
             </div>
-            <p v-if="error" class="text-red-500 mt-4">
+            <p
+              v-if="error"
+              class="text-red-500 mt-4">
               {{ error }}
             </p>
             <button
               type="submit"
-              class="w-full py-3 bg-[#38c172] rounded text-[#1e1f26] text-base font-medium cursor-pointer transition hover:bg-[#248C46] hover:text-white"
-            >
+              class="w-full py-3 bg-[#38c172] rounded text-[#1e1f26] text-base font-medium cursor-pointer transition hover:bg-[#248C46] hover:text-white">
               Log In
             </button>
           </form>
@@ -118,14 +118,15 @@
                 : 'max-h-0 opacity-0 p-0 mt-0'
             "
             class="overflow-hidden transition-all duration-500 ease-in-out bg-[#323444] rounded"
-            ref="resetBox"
-          >
+            ref="resetBox">
             <h2 class="mt-0 text-2xl font-semibold mb-4">
               Reset Your Password
             </h2>
             <form>
               <div class="mb-5">
-                <label for="reset-email" class="block mb-1 text-sm"
+                <label
+                  for="reset-email"
+                  class="block mb-1 text-sm"
                   >Email</label
                 >
                 <input
@@ -133,20 +134,22 @@
                   id="reset-email"
                   type="text"
                   placeholder="your@email.com"
-                  class="w-full py-3 px-4 rounded bg-[#b3b4ba] text-black border-none focus:bg-[white] focus:outline-none focus:ring-2 focus:ring-[#38c172] text-base"
-                />
+                  class="w-full py-3 px-4 rounded bg-[#b3b4ba] text-black border-none focus:bg-[white] focus:outline-none focus:ring-2 focus:ring-[#38c172] text-base" />
               </div>
               <button
                 type="button"
                 @click="handleResetPassword"
-                class="w-full py-3 bg-[#3a3c46] text-[#ececf1] rounded text-base cursor-pointer transition hover:bg-[#4b4e5a]"
-              >
+                class="w-full py-3 bg-[#3a3c46] text-[#ececf1] rounded text-base cursor-pointer transition hover:bg-[#4b4e5a]">
                 Send Password Reset Email
               </button>
-              <p v-if="resetError" class="text-red-400 mt-2">
+              <p
+                v-if="resetError"
+                class="text-red-400 mt-2">
                 {{ resetError }}
               </p>
-              <p v-if="resetSuccess" class="text-green-400 mt-2">
+              <p
+                v-if="resetSuccess"
+                class="text-green-400 mt-2">
                 {{ resetSuccess }}
               </p>
             </form>
@@ -155,8 +158,7 @@
       </div>
 
       <footer
-        class="max-w-[960px] w-full p-4 flex justify-center items-center mt-4"
-      >
+        class="max-w-[960px] w-full p-4 flex justify-center items-center mt-4">
         <div class="text-sm text-[#ececf1]">
           Need an account?
           <span
@@ -187,6 +189,7 @@ import {
   getSocialSignInErrorMessage,
 } from "@/utils/errorHandlers";
 import { useAuthStore } from "@/stores/useAuthStore";
+import { useMsgStore } from "@/stores/useMsgStore";
 import GoogleIcon from "@/components/icons/GoogleIcon.vue";
 import GithubIcon from "@/components/icons/GithubIcon.vue";
 
@@ -203,35 +206,62 @@ const route = useRoute();
 const resetEmail = ref("");
 const resetError = ref("");
 const resetSuccess = ref("");
+const msg = useMsgStore();
 
 const goSignup = () => {
   router.push("/signup");
 };
+
 const login = async () => {
   try {
     const { token } = await loginWithEmail(auth, email.value, password.value);
     authStore.setToken(token);
     await syncUser();
-    alert("登入成功！");
-    router.push(route.query.redirect || "/");
+    msg.open({
+      title: "Success",
+      message: "Login successful！",
+      variant: "success",
+      confirmText: "OK",
+      onConfirm: () => {
+        router.push(route.query.redirect || "/");
+      },
+    });
   } catch (e) {
     error.value = getLoginErrorMessage(e.code);
+    msg.open({
+      title: "Error",
+      message: error.value,
+      variant: "warning",
+      confirmText: "OK",
+    });
     console.error(e);
   }
 };
+
 const socialSignIn = async (provider) => {
   try {
     const { token } = await loginWithProvider(auth, provider);
     authStore.setToken(token);
     await syncUser();
-    alert(
-      `${
+    msg.open({
+      title: "Success",
+      message: `${
         provider.providerId.includes("google") ? "Google" : "GitHub"
-      } sign in successful!`
-    );
-    router.push(route.query.redirect || "/");
+      } sign in successful!`,
+      variant: "success",
+      confirmText: "OK",
+      onConfirm: () => {
+        router.push(route.query.redirect || "/");
+      },
+    });
   } catch (e) {
-    alert(getSocialSignInErrorMessage(e.code, provider.providerId));
+    const msgText = getSocialSignInErrorMessage(e.code, provider.providerId);
+    msg.open({
+      title: "Error",
+      message: msgText,
+      variant: "warning",
+      confirmText: "OK",
+    });
     console.error(e);
   }
 };

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -2,26 +2,27 @@
   <div class="flex justify-center items-start min-h-screen bg py-24 px-4">
     <div class="w-full max-w-md bg-white rounded-xl shadow-lg p-8">
       <form class="mb-4">
-        <input
-          type="hidden"
-          name="authenticity_token"
-          value="..." />
+        <input type="hidden" name="authenticity_token" value="..." />
         <button
           type="button"
           @click="() => socialSignIn(new GoogleAuthProvider())"
-          class="w-full flex items-center justify-center gap-2 bg-gray-700 text-white font-bold py-3 rounded-md cursor-pointer hover:bg-black transition duration-200">
+          class="w-full flex items-center justify-center gap-2 bg-gray-700 text-white font-bold py-3 rounded-md cursor-pointer hover:bg-black transition duration-200"
+        >
           <img
             src="https://img.icons8.com/color/16/000000/google-logo.png"
-            alt="Google logo" />
+            alt="Google logo"
+          />
           <span>Sign Up with Google</span>
         </button>
         <button
           type="button"
           @click="() => socialSignIn(new GithubAuthProvider())"
-          class="w-full flex items-center justify-center gap-2 bg-gray-700 text-white font-bold py-3 rounded-md cursor-pointer hover:bg-black transition duration-200 mt-3">
+          class="w-full flex items-center justify-center gap-2 bg-gray-700 text-white font-bold py-3 rounded-md cursor-pointer hover:bg-black transition duration-200 mt-3"
+        >
           <img
             src="https://img.icons8.com/ios-glyphs/24/ffffff/github.png"
-            alt="GitHub logo" />
+            alt="GitHub logo"
+          />
           <span>Sign Up with GitHub</span>
         </button>
       </form>
@@ -30,7 +31,8 @@
 
       <button
         @click="showEmailForm = !showEmailForm"
-        class="w-full bg-gray-700 text-white font-bold py-3 rounded-md mb-4 cursor-pointer hover:bg-black transition duration-200">
+        class="w-full bg-gray-700 text-white font-bold py-3 rounded-md mb-4 cursor-pointer hover:bg-black transition duration-200"
+      >
         Sign Up with Email
       </button>
 
@@ -38,14 +40,11 @@
         @before-enter="beforeEnter"
         @enter="enter"
         @leave="leave"
-        :css="false">
-        <div
-          v-show="showEmailForm"
-          ref="emailSection">
+        :css="false"
+      >
+        <div v-show="showEmailForm" ref="emailSection">
           <form @submit.prevent="register">
-            <input
-              type="hidden"
-              value="..." />
+            <input type="hidden" value="..." />
 
             <div class="mb-4">
               <label
@@ -60,7 +59,8 @@
                 required
                 autocomplete="email"
                 maxlength="20"
-                class="w-full border border-gray-300 rounded px-3 py-2 text-black bg-gray-200 hover:bg-white transition" />
+                class="w-full border border-gray-300 rounded px-3 py-2 text-black bg-gray-200 hover:bg-white transition"
+              />
             </div>
 
             <div class="mb-4">
@@ -75,7 +75,8 @@
                 type="password"
                 autocomplete="new-password"
                 required
-                class="w-full border border-gray-300 rounded px-3 py-2 text-black bg-gray-200 hover:bg-white transition" />
+                class="w-full border border-gray-300 rounded px-3 py-2 text-black bg-gray-200 hover:bg-white transition"
+              />
 
               <ul class="text-xs text-gray-600 mt-2 list-disc pl-5">
                 <li>Include an <strong>UPPER</strong> and lowercase letter</li>
@@ -89,7 +90,8 @@
 
             <button
               type="submit"
-              class="w-full bg-green-500 text-white font-bold py-3 rounded-md mt-4 cursor-pointer hover:bg-gray-600 transition duration-200">
+              class="w-full bg-green-500 text-white font-bold py-3 rounded-md mt-4 cursor-pointer hover:bg-gray-600 transition duration-200"
+            >
               Submit
             </button>
           </form>
@@ -163,8 +165,10 @@ const socialSignIn = async (provider) => {
       } sign in successful!`,
       variant: "success",
       confirmText: "OK",
+      onConfirm: () => {
+        router.push("/trending");
+      },
     });
-    router.push("/trending");
   } catch (e) {
     const msgText = getSocialSignInErrorMessage(e.code, provider.providerId);
     msg.open({

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -2,27 +2,26 @@
   <div class="flex justify-center items-start min-h-screen bg py-24 px-4">
     <div class="w-full max-w-md bg-white rounded-xl shadow-lg p-8">
       <form class="mb-4">
-        <input type="hidden" name="authenticity_token" value="..." />
+        <input
+          type="hidden"
+          name="authenticity_token"
+          value="..." />
         <button
           type="button"
           @click="() => socialSignIn(new GoogleAuthProvider())"
-          class="w-full flex items-center justify-center gap-2 bg-gray-700 text-white font-bold py-3 rounded-md cursor-pointer hover:bg-black transition duration-200"
-        >
+          class="w-full flex items-center justify-center gap-2 bg-gray-700 text-white font-bold py-3 rounded-md cursor-pointer hover:bg-black transition duration-200">
           <img
             src="https://img.icons8.com/color/16/000000/google-logo.png"
-            alt="Google logo"
-          />
+            alt="Google logo" />
           <span>Sign Up with Google</span>
         </button>
         <button
           type="button"
           @click="() => socialSignIn(new GithubAuthProvider())"
-          class="w-full flex items-center justify-center gap-2 bg-gray-700 text-white font-bold py-3 rounded-md cursor-pointer hover:bg-black transition duration-200 mt-3"
-        >
+          class="w-full flex items-center justify-center gap-2 bg-gray-700 text-white font-bold py-3 rounded-md cursor-pointer hover:bg-black transition duration-200 mt-3">
           <img
             src="https://img.icons8.com/ios-glyphs/24/ffffff/github.png"
-            alt="GitHub logo"
-          />
+            alt="GitHub logo" />
           <span>Sign Up with GitHub</span>
         </button>
       </form>
@@ -31,8 +30,7 @@
 
       <button
         @click="showEmailForm = !showEmailForm"
-        class="w-full bg-gray-700 text-white font-bold py-3 rounded-md mb-4 cursor-pointer hover:bg-black transition duration-200"
-      >
+        class="w-full bg-gray-700 text-white font-bold py-3 rounded-md mb-4 cursor-pointer hover:bg-black transition duration-200">
         Sign Up with Email
       </button>
 
@@ -40,11 +38,14 @@
         @before-enter="beforeEnter"
         @enter="enter"
         @leave="leave"
-        :css="false"
-      >
-        <div v-show="showEmailForm" ref="emailSection">
+        :css="false">
+        <div
+          v-show="showEmailForm"
+          ref="emailSection">
           <form @submit.prevent="register">
-            <input type="hidden" value="..." />
+            <input
+              type="hidden"
+              value="..." />
 
             <div class="mb-4">
               <label
@@ -59,8 +60,7 @@
                 required
                 autocomplete="email"
                 maxlength="20"
-                class="w-full border border-gray-300 rounded px-3 py-2 text-black bg-gray-200 hover:bg-white transition"
-              />
+                class="w-full border border-gray-300 rounded px-3 py-2 text-black bg-gray-200 hover:bg-white transition" />
             </div>
 
             <div class="mb-4">
@@ -75,8 +75,7 @@
                 type="password"
                 autocomplete="new-password"
                 required
-                class="w-full border border-gray-300 rounded px-3 py-2 text-black bg-gray-200 hover:bg-white transition"
-              />
+                class="w-full border border-gray-300 rounded px-3 py-2 text-black bg-gray-200 hover:bg-white transition" />
 
               <ul class="text-xs text-gray-600 mt-2 list-disc pl-5">
                 <li>Include an <strong>UPPER</strong> and lowercase letter</li>
@@ -90,8 +89,7 @@
 
             <button
               type="submit"
-              class="w-full bg-green-500 text-white font-bold py-3 rounded-md mt-4 cursor-pointer hover:bg-gray-600 transition duration-200"
-            >
+              class="w-full bg-green-500 text-white font-bold py-3 rounded-md mt-4 cursor-pointer hover:bg-gray-600 transition duration-200">
               Submit
             </button>
           </form>
@@ -113,9 +111,11 @@ import {
 } from "@/utils/errorHandlers";
 import { syncUser } from "@/utils/user.js";
 import { useAuthStore } from "@/stores/useAuthStore";
+import { useMsgStore } from "@/stores/useMsgStore";
 
 const authStore = useAuthStore();
 const router = useRouter();
+const msg = useMsgStore();
 const showEmailForm = ref(false);
 const email = ref("");
 const password = ref("");
@@ -128,13 +128,25 @@ const register = async () => {
   try {
     await registerWithEmail(auth, email.value, password.value);
     success.value = "Registration successful！";
-    alert(success.value);
+    msg.open({
+      title: "Success",
+      message: success.value,
+      variant: "success",
+      confirmText: "OK",
+      onConfirm: () => {
+        router.push("/trending");
+      },
+    });
     await syncUser();
-    router.push("/trending");
   } catch (e) {
-    const msg = getRegisterErrorMessage(e.code);
-    alert(msg);
-    error.value = msg;
+    const msgText = getRegisterErrorMessage(e.code);
+    msg.open({
+      title: "Error",
+      message: msgText,
+      variant: "warning",
+      confirmText: "OK",
+    });
+    error.value = msgText;
     console.error("Registration failed:", e);
   }
 };
@@ -144,14 +156,23 @@ const socialSignIn = async (provider) => {
     const { token } = await loginWithProvider(auth, provider);
     authStore.setToken(token);
     await syncUser();
-    alert(
-      `${
+    msg.open({
+      title: "Success",
+      message: `${
         provider.providerId.includes("google") ? "Google" : "GitHub"
-      } sign in successful!`
-    );
+      } sign in successful!`,
+      variant: "success",
+      confirmText: "OK",
+    });
     router.push("/trending");
   } catch (e) {
-    alert(getSocialSignInErrorMessage(e.code, provider.providerId));
+    const msgText = getSocialSignInErrorMessage(e.code, provider.providerId);
+    msg.open({
+      title: "Error",
+      message: msgText,
+      variant: "warning",
+      confirmText: "OK",
+    });
     console.error(e);
   }
 };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4a04c43f-7dfd-4124-8a62-58820f171aa7)
以上是退訂的流程
![image](https://github.com/user-attachments/assets/6ac461ad-2910-46c3-a188-b09a34602cb6)
![image](https://github.com/user-attachments/assets/53563b1b-6d1b-48fd-8189-0b3af78f85f0)
![image](https://github.com/user-attachments/assets/19c6e751-b59c-422a-b081-d8001308bf0a)

有各種互動條件加入的需要自行導入confirmmodal 例如退訂流程 需要輸入username做確認才能退訂

沒有互動條件的 只要引入msgstore 在script寫function  就可以全站使用這個提醒訊息

closes #199 
