### PR TITLE
[feat] /:username 路由若未找到使用者則導到404頁面

### DIFF
--- a/src/layouts/ProfileLayout.vue
+++ b/src/layouts/ProfileLayout.vue
@@ -213,6 +213,7 @@ const fetchUserInfo = async () => {
     }
   } catch (e) {
     userInfo.value = null;
+    router.replace({ name: "not-found" });
   }
 };
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -162,11 +162,11 @@ const router = createRouter({
       component: () => import("../views/PenDetailPage.vue"),
       meta: { canBeModal: true },
     },
-    /*{
+    {
       path: '/:pathMatch(.*)*',
       name: 'not-found',
       component: () => import("../views/NotFound.vue")
-    }*/
+    }
   ],
 });
 


### PR DESCRIPTION
close #180 
#### 變更
1. 啟動404頁面
2. 因為 /:username 動態路由會匹配所有路由導致 404 的路由設定失效，所以在 Profile 頁抓取使用者是否存在的邏輯中如果該路由沒有使用者則導頁到 404 頁面