### PR TITLE
[feat] 新增 Toast 通知系統

### DIFF
--- a/src/components/PenDetails/PenShareBox.vue
+++ b/src/components/PenDetails/PenShareBox.vue
@@ -16,7 +16,9 @@
 </template>
 
 <script setup>
-import { useRoute } from "vue-router";
+import { useToastStore } from "@/stores/useToastStore";
+const toastStore = useToastStore();
+console.log(toastStore);
 
 const props = defineProps({
   penId: {
@@ -35,11 +37,16 @@ function copyLink() {
   navigator.clipboard
     .writeText(url)
     .then(() => {
-      // 可換成 emit 或 toast
-      alert("Link copied!");
+      toastStore.showToast({
+        message: "Link copied!",
+        variant: "success",
+      });
     })
     .catch(() => {
-      alert("Copy failed, please manually copy the link.");
+      toastStore.showToast({
+        message: "Copy failed, please manually copy the link.",
+        variant: "danger",
+      });
     });
 }
 </script>

--- a/src/components/Toast/Toast.vue
+++ b/src/components/Toast/Toast.vue
@@ -1,0 +1,47 @@
+<template>
+  <div
+    :class="[
+      'p-4 border-l-4 rounded bg-black text-white shadow-lg transition-transform duration-300 ease-out',
+      variantClass,
+    ]"
+    @mouseenter="clearTimer"
+    @mouseleave="startTimer"
+  >
+    <div class="flex justify-between items-center">
+      <span>{{ message }}</span>
+      <button @click="$emit('close')" class="ml-4 text-white">&times;</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, onBeforeUnmount } from 'vue';
+const props = defineProps({
+  message: String,
+  variant: String,
+  duration: Number,
+  id: String,
+});
+const emit = defineEmits(['close']);
+
+let timer;
+function startTimer() {
+  timer = setTimeout(() => emit('close'), props.duration);
+}
+function clearTimer() {
+  clearTimeout(timer);
+}
+onMounted(startTimer);
+onBeforeUnmount(clearTimer);
+
+const variantClass = computed(() => {
+  switch (props.variant) {
+    case 'danger':
+      return 'border-cc-red';
+    case 'success':
+      return 'border-cc-green';
+    default:
+      return 'border-cc-yellow';
+  }
+});
+</script>

--- a/src/components/Toast/Toast.vue
+++ b/src/components/Toast/Toast.vue
@@ -1,47 +1,77 @@
 <template>
   <div
     :class="[
-      'p-4 border-l-4 rounded bg-black text-white shadow-lg transition-transform duration-300 ease-out',
+      'px-1.5 py-0.5 border-2 rounded bg-black text-white text-sm shadow-lg transition-all duration-300 ease-out',
       variantClass,
+      isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4',
     ]"
-    @mouseenter="clearTimer"
-    @mouseleave="startTimer"
+    @mouseenter="pauseAutoClose"
+    @mouseleave="resumeAutoClose"
   >
     <div class="flex justify-between items-center">
       <span>{{ message }}</span>
-      <button @click="$emit('close')" class="ml-4 text-white">&times;</button>
+      <button @click="$emit('close')" class="ml-2 text-white">&times;</button>
     </div>
   </div>
 </template>
 
 <script setup>
-import { onMounted, onBeforeUnmount } from 'vue';
+import { onMounted, onBeforeUnmount, computed, ref } from "vue";
 const props = defineProps({
   message: String,
   variant: String,
-  duration: Number,
+  duration: {
+    type: Number,
+    default: 3000,
+  },
   id: String,
 });
-const emit = defineEmits(['close']);
+const emit = defineEmits(["close"]);
+const isVisible = ref(false);
+let autoCloseTimer = null;
+let fadeOutTimer = null;
 
-let timer;
-function startTimer() {
-  timer = setTimeout(() => emit('close'), props.duration);
+const TRANSITION_DURATION = props.duration || 300;
+
+function startEnterAnimation() {
+  setTimeout(() => {
+    isVisible.value = true;
+  }, 50);
 }
-function clearTimer() {
-  clearTimeout(timer);
+function resumeAutoClose() {
+  autoCloseTimer = setTimeout(() => handleClose(), props.duration);
 }
-onMounted(startTimer);
-onBeforeUnmount(clearTimer);
+function pauseAutoClose() {
+  clearTimeout(autoCloseTimer);
+}
+
+function handleClose() {
+  isVisible.value = false;
+
+  fadeOutTimer = setTimeout(() => {
+    emit("close");
+  }, TRANSITION_DURATION); // 需與 transition 時間一致
+}
+
+onMounted(() => {
+  startEnterAnimation();
+  resumeAutoClose();
+});
+onBeforeUnmount(() => {
+  clearTimeout(autoCloseTimer);
+  clearTimeout(fadeOutTimer);
+});
 
 const variantClass = computed(() => {
   switch (props.variant) {
-    case 'danger':
-      return 'border-cc-red';
-    case 'success':
-      return 'border-cc-green';
+    case "danger":
+      return "border-cc-red";
+    case "success":
+      return "border-cc-green";
+    case "warning":
+      return "border-cc-green";
     default:
-      return 'border-cc-yellow';
+      return "border-cc-yellow";
   }
 });
 </script>

--- a/src/components/Toast/ToastContainer.vue
+++ b/src/components/Toast/ToastContainer.vue
@@ -1,6 +1,5 @@
-<!-- ToastContainer.vue -->
 <template>
-  <div class="fixed top-4 left-1/2 -translate-x-1/2 z-50 flex flex-col gap-3 w-full max-w-sm">
+  <div class="fixed top-4 left-1/2 -translate-x-1/2 z-50 flex flex-col gap-3 max-w-sm items-center">
     <Toast
       v-for="toast in toastStore.toasts"
       :key="toast.id"
@@ -11,7 +10,7 @@
 </template>
 <script setup>
 import { useToastStore } from '@/stores/useToastStore'
-import Toast from '@/components/Toast/Toast.vue' // 單一 toast 元件
+import Toast from '@/components/Toast/Toast.vue'
 
 const toastStore = useToastStore()
 </script>

--- a/src/components/ui/ToastContainer.vue
+++ b/src/components/ui/ToastContainer.vue
@@ -1,0 +1,17 @@
+<!-- ToastContainer.vue -->
+<template>
+  <div class="fixed top-4 left-1/2 -translate-x-1/2 z-50 flex flex-col gap-3 w-full max-w-sm">
+    <Toast
+      v-for="toast in toastStore.toasts"
+      :key="toast.id"
+      v-bind="toast"
+      @close="toastStore.removeToast(toast.id)"
+    />
+  </div>
+</template>
+<script setup>
+import { useToastStore } from '@/stores/useToastStore'
+import Toast from '@/components/Toast/Toast.vue' // 單一 toast 元件
+
+const toastStore = useToastStore()
+</script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -38,6 +38,8 @@
       ><p>{{ msg.message }}</p></template
     >
   </ConfirmModal>
+
+  <ToastContainer />
 </template>
 
 <script setup>
@@ -49,6 +51,7 @@ import MainSidebar from "@/components/MainSidebar.vue";
 import PenDetailModal from "@/components/PenDetails/PenDetailModal.vue";
 import { useMsgStore } from "@/stores/useMsgStore";
 import ConfirmModal from "@/components/ui/ConfirmModal.vue";
+import ToastContainer from "@/components/ui/ToastContainer.vue";
 
 const msg = useMsgStore();
 const modalStore = useModalStore();

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -51,7 +51,7 @@ import MainSidebar from "@/components/MainSidebar.vue";
 import PenDetailModal from "@/components/PenDetails/PenDetailModal.vue";
 import { useMsgStore } from "@/stores/useMsgStore";
 import ConfirmModal from "@/components/ui/ConfirmModal.vue";
-import ToastContainer from "@/components/ui/ToastContainer.vue";
+import ToastContainer from "@/components/Toast/ToastContainer.vue";
 
 const msg = useMsgStore();
 const modalStore = useModalStore();

--- a/src/stores/useToastStore.js
+++ b/src/stores/useToastStore.js
@@ -8,11 +8,6 @@ export const useToastStore = defineStore('toast', () => {
   function showToast({ message, variant = 'warning', duration = 3000 }) {
     const id = Date.now().toString();
     toasts.value.push({ id, message, variant, duration });
-
-    // 自動移除
-    setTimeout(() => {
-      removeToast(id);
-    }, duration);
   }
 
   function removeToast(id) {

--- a/src/stores/useToastStore.js
+++ b/src/stores/useToastStore.js
@@ -1,0 +1,23 @@
+// useToastStore.ts
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useToastStore = defineStore('toast', () => {
+  const toasts = ref([]);
+
+  function showToast({ message, variant = 'warning', duration = 3000 }) {
+    const id = Date.now().toString();
+    toasts.value.push({ id, message, variant, duration });
+
+    // 自動移除
+    setTimeout(() => {
+      removeToast(id);
+    }, duration);
+  }
+
+  function removeToast(id) {
+    toasts.value = toasts.value.filter((t) => t.id !== id);
+  }
+
+  return { toasts, showToast, removeToast };
+});


### PR DESCRIPTION
close #112
新增一組可複用的 Toast 元件，用於顯示提示、錯誤、成功等簡短訊息。支援淡入淡出動畫與自動消失邏輯。
`PenShareBox.vue` 的提示訊息與錯誤訊息改為以 toast 顯示
![image](https://github.com/user-attachments/assets/4c61f287-14fa-4038-beda-0bdb0f00be51)


### 組成
1. `Toast.vue`
單一 `Toast` 卡片元件，支援：
`message`: 顯示內容
`variant`: 類型（`success`, `danger`, `warning`, `default`）
`duration`: 顯示時間（預設 3000ms）
動畫：淡入 + 淡出動畫效果
滑鼠 hover 時會暫停自動關閉

2. `ToastContainer.vue`
負責統一顯示畫面中所有 toast，採用 fixed 定位，會自動疊加顯示。

3. `useToastStore.js`
使用 Pinia 定義 toast 狀態與操作方法，包含：
`toasts`: 所有 toast 資料
`showToast`: 新增 toast
`removeToast`: 移除 toast（由 `@close` 事件觸發）

### 使用方式
1. 已在全域 `MainLayout.vue` 中加入 `ToastCOntainer`
```javascritpe
<template>
  <ToastContainer />
</template>

<script setup>
import ToastContainer from '@/components/Toast/ToastContainer.vue'
</script>
```

2. 可再任意地方引進 `useToastStore` 後呼叫 `showToast`
```javascript
import { useToastStore } from '@/stores/useToastStore.js'

const toast = useToastStore()

toast.showToast({
  message: '儲存成功',
  variant: 'success', // optional: 'danger' | 'warning' | 'default'
  duration: 3000 // optional
})
```

### 自訂樣式
顏色透過 variant 控制：

`success` → 綠框
`danger` → 紅框
`warning` / `default` → 黃框

### 代辦事項
 - `default` 樣式可能可以改成其他樣式
 - 站內所有 `alert` 跳窗改為 `Toast`