### PR TITLE
[feat] 新增使用者頭像上傳裁切功能，新增 vue-advanced-cropper + Headless UI 兩個套件

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@guolao/vue-monaco-editor": "^1.5.5",
+        "@headlessui/vue": "^1.7.23",
         "@stripe/stripe-js": "^7.3.1",
         "@tailwindcss/cli": "^4.1.6",
         "@tailwindcss/postcss": "^4.1.6",
@@ -24,6 +25,7 @@
         "swiper": "^11.2.8",
         "vite-plugin-monaco-editor": "^1.1.0",
         "vue": "^3.5.13",
+        "vue-advanced-cropper": "^2.8.9",
         "vue-router": "^4.5.0"
       },
       "devDependencies": {
@@ -1601,6 +1603,21 @@
         }
       }
     },
+    "node_modules/@headlessui/vue": {
+      "version": "1.7.23",
+      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
+      "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/vue-virtual": "^3.0.0-beta.60"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -2666,6 +2683,32 @@
         "vite": "^5.2.0 || ^6"
       }
     },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.11.tgz",
+      "integrity": "sha512-ORL6UyuZJ0D9X33LDR4TcgcM+K2YiS2j4xbvH1vnhhObwR1Z4dKwPTL/c0kj2Yeb4Yp2lBv1wpyVaqlohk8zpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.11.tgz",
+      "integrity": "sha512-QPutNYlSATS0a2fmTEbMgaQkk/pe1p+39OJVbmQ5/l1d8Txe1IkOJeeweYXygmF1tnruCh6NKkt1kIIYDKwgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.11"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -3117,6 +3160,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3223,6 +3272,12 @@
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -3327,6 +3382,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/easy-bem": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/easy-bem/-/easy-bem-1.1.1.tgz",
+      "integrity": "sha512-GJRqdiy2h+EXy6a8E6R+ubmqUM08BK0FWNq41k24fup6045biQ8NXxoXimiwegMQvFFV3t1emADdGNL1TlS61A==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.151",
@@ -5338,6 +5399,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-advanced-cropper": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/vue-advanced-cropper/-/vue-advanced-cropper-2.8.9.tgz",
+      "integrity": "sha512-1jc5gO674kVGpJKekoaol6ZlwaF5VYDLSBwBOUpViW0IOrrRsyLw6XNszjEqgbavvqinlKNS6Kqlom3B5M72Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.6",
+        "debounce": "^1.2.0",
+        "easy-bem": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@guolao/vue-monaco-editor": "^1.5.5",
+    "@headlessui/vue": "^1.7.23",
     "@stripe/stripe-js": "^7.3.1",
     "@tailwindcss/cli": "^4.1.6",
     "@tailwindcss/postcss": "^4.1.6",
@@ -25,6 +26,7 @@
     "swiper": "^11.2.8",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vue": "^3.5.13",
+    "vue-advanced-cropper": "^2.8.9",
     "vue-router": "^4.5.0"
   },
   "devDependencies": {

--- a/src/components/ui/AvatarUploaderModal.vue
+++ b/src/components/ui/AvatarUploaderModal.vue
@@ -1,0 +1,143 @@
+<template>
+  <TransitionRoot appear :show="isOpen" as="template">
+    <Dialog as="div" class="relative z-50" @close="closeModal">
+      <TransitionChild
+        as="template"
+        enter="ease-out duration-300"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="ease-in duration-200"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
+      >
+        <div class="fixed inset-0 bg-black/25"></div>
+      </TransitionChild>
+
+      <div class="fixed inset-0 overflow-y-auto">
+        <div
+          class="flex min-h-full items-center justify-center p-4 text-center"
+        >
+          <TransitionChild
+            as="template"
+            enter="ease-out duration-300"
+            enter-from="opacity-0 scale-95"
+            enter-to="opacity-100 scale-100"
+            leave="ease-in duration-200"
+            leave-from="opacity-100 scale-100"
+            leave-to="opacity-0 scale-95"
+          >
+            <DialogPanel
+              class="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
+            >
+              <DialogTitle
+                as="h3"
+                class="text-lg font-medium leading-6 text-gray-900 mb-4"
+              >
+                Upload and crop image
+              </DialogTitle>
+              <!-- 拖曳上傳區或剪裁區 -->
+              <div
+                v-if="!imageSrc"
+                class="border border-dashed border-gray-300 p-8 text-center cursor-pointer hover:bg-gray-50"
+                @dragover.prevent
+                @drop.prevent="onDrop"
+                @click="triggerFileInput"
+              >
+                <input
+                  ref="fileInput"
+                  type="file"
+                  accept="image/*"
+                  class="hidden"
+                  @change="onFileChange"
+                />
+                <p class="text-gray-500">
+                  Drag and drop an image here, or click to select a file
+                </p>
+              </div>
+
+              <div v-else>
+                <Cropper
+                  class="h-96 w-full bg-gray-100"
+                  :src="imageSrc"
+                  :stencil-props="{ aspectRatio: 1 }"
+                  :auto-zoom="true"
+                  :resize-image="{ enabled: true }"
+                  ref="cropperRef"
+                />
+              </div>
+              <!-- 底部操作列 -->
+              <div class="mt-6 flex justify-end gap-2">
+                <button
+                  class="px-4 py-2 text-sm text-gray-700 hover:underline"
+                  @click="closeModal"
+                >
+                  Cancel
+                </button>
+                <button
+                  v-if="imageSrc"
+                  class="px-4 py-2 bg-blue-600 text-white rounded-md"
+                  @click="save"
+                >
+                  Save
+                </button>
+              </div>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+<script setup>
+import { ref } from "vue";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  TransitionChild,
+  TransitionRoot,
+} from "@headlessui/vue";
+import { Cropper } from "vue-advanced-cropper";
+import "vue-advanced-cropper/dist/style.css";
+
+const props = defineProps({
+  isOpen: Boolean,
+});
+const emit = defineEmits(["close", "submit"]);
+
+const imageSrc = ref(null);
+const cropperRef = ref(null);
+const fileInput = ref(null);
+
+const closeModal = () => {
+  imageSrc.value = null;
+  emit("close");
+};
+
+const triggerFileInput = () => {
+  fileInput.value.click();
+};
+
+const onFileChange = (e) => {
+  const file = e.target.files[0];
+  if (file) imageSrc.value = URL.createObjectURL(file);
+};
+
+const onDrop = (e) => {
+  const file = e.dataTransfer.files[0];
+  if (file) imageSrc.value = URL.createObjectURL(file);
+};
+
+const save = () => {
+  const cropper = cropperRef.value;
+  if (!cropper) return;
+  const canvas = cropper.getResult().canvas;
+  canvas.toBlob((blob) => {
+    if (blob) emit("submit", blob);
+    closeModal();
+  }, "image/jpeg");
+};
+</script>
+<style scoped>
+/* 其他style */
+</style>

--- a/src/components/ui/AvatarUploaderModal.vue
+++ b/src/components/ui/AvatarUploaderModal.vue
@@ -121,11 +121,15 @@ const triggerFileInput = () => {
 const onFileChange = (e) => {
   const file = e.target.files[0];
   if (file) imageSrc.value = URL.createObjectURL(file);
+  emit('filename', file.name);
 };
 
 const onDrop = (e) => {
   const file = e.dataTransfer.files[0];
-  if (file) imageSrc.value = URL.createObjectURL(file);
+  if (file) {
+    imageSrc.value = URL.createObjectURL(file);
+    emit('filename', file.name)
+  }
 };
 
 const save = () => {


### PR DESCRIPTION
- 新增 AvatarUploaderModal 組件，支援圖片裁切（固定正方形）
- 使用者可透過拖曳或點擊上傳圖片
- 整合 Headless UI Modal 動畫與 Cropper 裁切
- 圖片裁切後轉成 blob 上傳，保留使用者原始檔名
- UI 整合至個人檔案設定頁，含預覽與清除功能

### 新增套件與用途
`@headlessui/vue` – 無樣式彈窗元件
用於建立可自定樣式的 Modal 視窗，實現「上傳與裁切頭像」的彈出視窗效果，並搭配過場動畫（TransitionRoot / TransitionChild）。

`vue-advanced-cropper` – 圖片裁切工具
提供使用者裁切上傳圖片的功能，支援拖曳、縮放、固定比例（本功能設定為正方形），裁切完成後轉為 Blob 並送出上傳。

### 功能演示影片



https://github.com/user-attachments/assets/a7ad15a2-4f76-482e-96fa-470127beef2a


