### PR TITLE
[fix] 總layout手機板右側被裁切問題, Header 與部分頁面RWD調整，部分頁面顯示 Pens 改名為 Dose

### DIFF
--- a/src/components/SubHeader.vue
+++ b/src/components/SubHeader.vue
@@ -1,10 +1,12 @@
 <template>
   <header
     ref="dropdownRef"
-    class="relative bg-cc-20 text-cc-1 w-full px-4 py-2 border-b-3 border-cc-14 flex items-center gap-4"
+    class="relative bg-cc-20 text-cc-1 w-full px-2 py-2 sm:px-4 sm:py-2 border-b-3 border-cc-14 flex items-center gap-2 sm:gap-4"
   >
     <!-- Logo + SidebarToggleIcon：830px 以下顯示 -->
-    <div class="flex items-center space-x-2 flex-shrink-0 hidden max-[830px]:flex">
+    <div
+      class="flex items-center space-x-2 flex-shrink-0 hidden max-[830px]:flex"
+    >
       <img
         src="https://blog.codepen.io/wp-content/uploads/2012/06/Button-Fill-White-Large.png"
         class="w-8 h-8"
@@ -12,7 +14,7 @@
       />
       <button
         @click.stop="isMenuOpen = !isMenuOpen"
-        class="w-10 h-10 flex items-center justify-center bg-cc-14 hover:bg-cc-13 rounded transition"
+        class="w-9 h-9 flex items-center justify-center bg-cc-14 hover:bg-cc-13 rounded transition"
         title="Toggle Navigation"
       >
         <SidebarToggleIcon :expanded="isMenuOpen" />
@@ -39,41 +41,46 @@
     </div>
 
     <!-- 搜尋欄 -->
-    <div class="relative h-9 ml-2 w-full max-w-[320px]">
-      <i
-        class="fas fa-search absolute left-3 top-1/2 transform -translate-y-1/2 text-cc-10"
-      ></i>
-      <form @submit.prevent="handleSearchSubmit">
-        <input
-          type="text"
-          placeholder="Search Codecaine..."
-          class="bg-cc-14 text-cc-1 pl-10 pr-4 py-2 rounded w-full h-full placeholder-cc-10 focus:outline-none"
-          v-model="searchKeyword"
-          @focus="searchFocused = true"
-          @blur="searchFocused = false"
-        />
-      </form>
+    <div class="flex-1 flex justify-center">
+      <div class="relative h-9 ml-2 w-full min-w-0 max-w-[320px]">
+        <i
+          class="fas fa-search absolute left-3 top-1/2 transform -translate-y-1/2 text-cc-10"
+        ></i>
+        <form @submit.prevent="handleSearchSubmit">
+          <input
+            type="text"
+            placeholder="Search Codecaine..."
+            class="bg-cc-14 text-cc-1 pl-10 pr-4 py-2 rounded w-full h-full placeholder-cc-10 focus:outline-none"
+            v-model="searchKeyword"
+            @focus="searchFocused = true"
+            @blur="searchFocused = false"
+          />
+        </form>
 
-      <!-- 浮出搜尋選單 -->
-      <div
-        v-if="searchFocused"
-        class="absolute left-0 mt-2 bg-cc-18 text-cc-1 rounded-md shadow-lg border border-cc-13 z-50 flex space-x-0.5 px-2 py-2"
-      >
-        <button
-          v-if="authStore.idToken"
-          @mousedown="selectSearchTab('your-work')"
-          class="px-2.5 py-1.5 rounded bg-cc-14 text-cc-1 text-xs hover:bg-cc-13 transition flex items-center"
+        <!-- 浮出搜尋選單 -->
+        <div
+          v-if="searchFocused"
+          class="absolute left-0 mt-2 bg-cc-18 text-cc-1 rounded shadow-lg z-50 flex space-x-1 px-1 py-1"
         >
-          <YourWorkIcon class="fill-current w-3 mr-1 text-cc-1" />
-          Your Work
-        </button>
-        <button
-          @mousedown="selectSearchTab('pens')"
-          class="px-2.5 py-1.5 rounded bg-cc-14 text-cc-1 text-sm hover:bg-cc-13 transition flex items-center"
-        >
-          <PensIcon class="fill-current w-3 mr-1" :class="searchTab === 'pens' ? 'text-cc-pens' : 'text-cc-1'" />
-          Pens
-        </button>
+          <button
+            v-if="authStore.idToken"
+            @mousedown="selectSearchTab('your-work')"
+            class="px-2 py-1 rounded bg-cc-14 text-cc-10 text-xs hover:bg-cc-13  hover:text-cc-5 transition flex items-center"
+          >
+            <YourWorkIcon class="fill-current w-3 mr-1 text-cc-10" />
+            Your Work
+          </button>
+          <button
+            @mousedown="selectSearchTab('pens')"
+            class="px-2 py-1 rounded bg-cc-14 text-cc-10 text-sm hover:bg-cc-13 hover:text-cc-5 transition flex items-center"
+          >
+            <PensIcon
+              class="fill-current w-3 mr-1"
+              :class="searchTab === 'pens' ? 'text-cc-pens' : 'text-cc-10'"
+            />
+            Doses
+          </button>
+        </div>
       </div>
     </div>
 
@@ -117,7 +124,7 @@
         <div
           class="bg-[#2c303a] hover:bg-[#1f2025] text-white text-sm px-4 py-3 font-medium text-center"
         >
-          {{ authStore.idToken ? '✏️ Caine' : 'Start Coding' }}
+          {{ authStore.idToken ? "✏️ Dose" : "Start Coding" }}
         </div>
       </div>
 
@@ -144,88 +151,91 @@
         Trending
       </div>
 
-      <!-- 未登入：Search Pains -->
+      <!-- 未登入：Search  -->
       <div
         v-if="!authStore.idToken"
         class="cursor-pointer hover:bg-[#131417] px-4 py-2 text-sm"
         @click="goToPath('/search')"
       >
-        Search Pains
+        Search Doses
       </div>
     </div>
   </header>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from "vue"
-import { useRoute, useRouter } from "vue-router"
-import { useAuthStore } from "@/stores/useAuthStore"
-import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon.vue"
-import UserMenu from "./UserMenu.vue"
-import YourWorkIcon from "@/components/icons/YourWorkIcon.vue"
-import PensIcon from "@/components/icons/PensIcon.vue"
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/useAuthStore";
+import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon.vue";
+import UserMenu from "./UserMenu.vue";
+import YourWorkIcon from "@/components/icons/YourWorkIcon.vue";
+import PensIcon from "@/components/icons/PensIcon.vue";
 
-const authStore = useAuthStore()
-const route = useRoute()
-const router = useRouter()
+const authStore = useAuthStore();
+const route = useRoute();
+const router = useRouter();
 
-const isMenuOpen = ref(false)
-const screenWidth = ref(window.innerWidth)
-const isCompactScreen = computed(() => screenWidth.value <= 830)
-const isVerySmallScreen = computed(() => screenWidth.value <= 634)
-const dropdownRef = ref(null)
+const isMenuOpen = ref(false);
+const screenWidth = ref(window.innerWidth);
+const isCompactScreen = computed(() => screenWidth.value <= 830);
+const isVerySmallScreen = computed(() => screenWidth.value <= 634);
+const dropdownRef = ref(null);
 
-const tabs = ["Your Work", "Following", "Trending"]
-const searchKeyword = ref("")
-const searchFocused = ref(false)
-const searchTab = ref("pens")
+const tabs = ["Your Work", "Following", "Trending"];
+const searchKeyword = ref("");
+const searchFocused = ref(false);
+const searchTab = ref("pens");
 
 const activeTab = computed(() => {
-  const path = route.path
-  if (path.startsWith("/your-work")) return "Your Work"
-  if (path.startsWith("/following")) return "Following"
-  if (path.startsWith("/trending")) return "Trending"
-  return ""
-})
+  const path = route.path;
+  if (path.startsWith("/your-work")) return "Your Work";
+  if (path.startsWith("/following")) return "Following";
+  if (path.startsWith("/trending")) return "Trending";
+  return "";
+});
 
 const goToPath = (pathOrLocation) => {
-  isMenuOpen.value = false
-  const path = typeof pathOrLocation === "string" ? pathOrLocation : pathOrLocation.path || ""
-  router.push(pathOrLocation)
-}
+  isMenuOpen.value = false;
+  const path =
+    typeof pathOrLocation === "string"
+      ? pathOrLocation
+      : pathOrLocation.path || "";
+  router.push(pathOrLocation);
+};
 
 const handleSearchSubmit = () => {
-  const trimmed = searchKeyword.value.trim().toLowerCase()
+  const trimmed = searchKeyword.value.trim().toLowerCase();
   if (trimmed) {
     router.push({
       path: "/search/pens",
       query: { q: trimmed },
-    })
+    });
   }
-}
+};
 
 const selectSearchTab = (tab) => {
-  searchTab.value = tab
-  if (tab === "your-work") goToPath("/your-work")
-  else if (tab === "pens") goToPath({ path: "/search/pens", query: { q: "" } })
-}
+  searchTab.value = tab;
+  if (tab === "your-work") goToPath("/your-work");
+  else if (tab === "pens") goToPath({ path: "/search/pens", query: { q: "" } });
+};
 
 const handleResize = () => {
-  screenWidth.value = window.innerWidth
-}
+  screenWidth.value = window.innerWidth;
+};
 
 const handleClickOutside = (event) => {
   if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
-    isMenuOpen.value = false
+    isMenuOpen.value = false;
   }
-}
+};
 
 onMounted(() => {
-  window.addEventListener("resize", handleResize)
-  document.addEventListener("click", handleClickOutside)
-})
+  window.addEventListener("resize", handleResize);
+  document.addEventListener("click", handleClickOutside);
+});
 onUnmounted(() => {
-  window.removeEventListener("resize", handleResize)
-  document.removeEventListener("click", handleClickOutside)
-})
+  window.removeEventListener("resize", handleResize);
+  document.removeEventListener("click", handleClickOutside);
+});
 </script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -2,18 +2,21 @@
   <div
     v-show="isMounted"
     class="layout transition-all duration-400 ease-in-out"
-    :style="{ gridTemplateColumns: layoutColumns }">
+    :style="{
+      gridTemplateColumns: layoutColumns,
+      gridTemplateAreas: layoutAreas,
+    }"
+  >
     <MainSidebar
       class="sidebar"
       v-if="!isCompactScreen"
-      @toggle="toggleSidebar" />
+      @toggle="toggleSidebar"
+    />
 
     <SubHeader class="header" />
 
     <RouterView v-slot="{ Component }">
-      <component
-        :is="Component"
-        class="content" />
+      <component :is="Component" class="content" />
     </RouterView>
 
     <SubFooter class="footer" />
@@ -22,7 +25,8 @@
       v-if="modalStore.showDetailModal"
       :pen-id="modalStore.penId"
       :from="modalStore.from"
-      @close="modalStore.closeModal" />
+      @close="modalStore.closeModal"
+    />
   </div>
   <ConfirmModal
     v-if="msg.show"
@@ -32,7 +36,8 @@
     :confirm-text="msg.confirmText"
     :cancel-text="msg.cancelText"
     @confirm="msg.close(true)"
-    @cancel="msg.close(false)">
+    @cancel="msg.close(false)"
+  >
     <template #title>{{ msg.title }}</template>
     <template #message
       ><p>{{ msg.message }}</p></template
@@ -62,6 +67,13 @@ const layoutColumns = computed(() => {
     return "1fr";
   }
   return isSidebarOpen.value ? "160px 1fr" : "12px 1fr";
+});
+
+const layoutAreas = computed(() => {
+  if (isCompactScreen.value) {
+    return `"header" "content" "footer"`;
+  }
+  return `"sidebar header" "sidebar content" "sidebar footer"`;
 });
 const toggleSidebar = () => {
   isSidebarOpen.value = !isSidebarOpen.value;
@@ -96,16 +108,12 @@ onUnmounted(() => {
 });
 </script>
 
-<style scoped>
+<style>
 .layout {
   display: grid;
-  grid-template-areas:
-    "sidebar header"
-    "sidebar content"
-    "sidebar footer";
   grid-template-rows: 75px 1fr auto;
   min-height: 100vh;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .sidebar {

--- a/src/views/Following.vue
+++ b/src/views/Following.vue
@@ -46,7 +46,7 @@
         v-for="(group, index) in chunkedCards"
         :key="'group-' + index"
       >
-        <div class="grid grid-cols-2 gap-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
           <PenCard
             v-for="pen in group"
             :key="pen.id"

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -183,7 +183,7 @@ function updateRouteQuery() {
                   class="fill-current w-3 mr-1.5"
                   :class="{ 'text-[#0EBEFF]': activeTab === 'pens' }"
                 />
-                Pens
+                Doses
               </a>
             </div>
           </div>

--- a/src/views/Trending.vue
+++ b/src/views/Trending.vue
@@ -16,7 +16,7 @@
         v-for="(group, index) in chunkedCards"
         :key="'group-' + index"
       >
-        <div class="grid grid-cols-2 gap-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
           <PenCard
             v-for="pen in group"
             :key="pen.id"

--- a/src/views/YourWork.vue
+++ b/src/views/YourWork.vue
@@ -25,7 +25,7 @@
             @click="goPen"
           >
             <PensIcon class="fill-current w-3 h-3 text-cc-1" />
-            <span>New Pen</span>
+            <span>New Dose</span>
           </button>
         </div>
       </div>
@@ -44,13 +44,13 @@
           <!-- Left Controls -->
           <div class="flex items-stretch space-x-2 relative">
             <!-- Search -->
-            <div class="flex rounded overflow-hidden">
+            <div class="flex-1 flex rounded overflow-hidden">
               <input
                 v-model="searchQuery"
                 @keyup.enter="handleSearch"
                 type="text"
                 placeholder="Search for..."
-                class="bg-input text-cc-1 text-sm px-3 py-1 placeholder-cc-9 focus:outline-none rounded-l"
+                class="min-w-0 bg-input text-cc-1 text-sm px-3 py-1 placeholder-cc-9 focus:outline-none rounded-l"
               />
               <button
                 @click="handleSearch"
@@ -98,7 +98,7 @@
 
             <!-- Tags 按鈕-->
             <div
-              v-if="activeTab === 'Pens'"
+              v-if="activeTab === 'Doses'"
               ref="tagsDropdownRef"
               @click.stop
               :class="[
@@ -336,8 +336,8 @@ const totalPages = ref(1);
 const hasNextPage = ref(false);
 
 // Tabs
-const tabs = ["Pens", "Deleted"];
-const activeTab = ref("Pens");
+const tabs = ["Doses", "Deleted"];
+const activeTab = ref("Doses");
 
 // Search + Filters bar
 const searchQuery = ref("");
@@ -397,8 +397,8 @@ const filteredTags = computed(() => {
 
 const emptyStateMessage = computed(() => {
   switch (activeTab.value) {
-    case "Pens":
-      return "No Pens.";
+    case "Doses":
+      return "No Doses.";
     default:
       return "Nothing here.";
   }
@@ -452,9 +452,8 @@ async function loadPens() {
     total.value = data.total;
     totalPages.value = data.totalPages;
     hasNextPage.value = data.hasNextPage;
-    console.log("🚀 載入我的 Pens 成功：", data);
   } catch (err) {
-    alert("Failed to load pens. Please try again later.");
+    alert("Failed to load doses. Please try again later.");
     // 可以加一個 toast 通知使用者
   }
 }
@@ -481,7 +480,7 @@ async function loadTags() {
 
 onMounted(() => {
   loadTags();
-  if (activeTab.value === "Pens") {
+  if (activeTab.value === "Doses") {
     loadPens();
   }
   if (activeTab.value === "Deleted") {
@@ -493,13 +492,13 @@ watch(
   [activeTab, filters, selectedTag, sortOption, sortDirection, viewMode],
   () => {
     page.value = 1;
-    if (activeTab.value === "Pens") loadPens();
+    if (activeTab.value === "Doses") loadPens();
   },
   { deep: true }
 );
 
 watch(page, () => {
-  if (activeTab.value === "Pens") loadPens();
+  if (activeTab.value === "Doses") loadPens();
 });
 
 watch(activeTab, () => {


### PR DESCRIPTION
 - 頁面MainLayout在手機上或螢幕小於448.568px後無法再適應縮小，目前不確定成因，所以先把這層設定的overflow hidden 改為 overflow auto，使在小螢幕時超出寬度的內容可滾動
 - 統一 Header 元件樣式高度
 - Trending 頁與 Following 頁手機板作品卡改為顯示單欄
 - Search 頁與 Following 頁面Pen 與 Pens 改為 Doses
