### PR TITLE
[feat] 將作品收藏狀態改為使用 pinia 做全域管理

### DIFF
--- a/src/api/favorites.js
+++ b/src/api/favorites.js
@@ -1,0 +1,17 @@
+import api from "@/config/api.js";
+
+export function addFavoriteAPI(pen_id) {
+  return api.post("/api/favorites", { pen_id });
+}
+
+export function removeFavoriteAPI(pen_id) {
+  return api.delete("/api/favorites", { data: { pen_id } });
+}
+
+export function checkFavoriteAPI(pen_id) {
+  return api.get(`/api/favorites/check/${pen_id}`);
+}
+
+export function countFavoritesAPI(pen_id) {
+  return api.get(`/api/favorites/count/${pen_id}`);
+}

--- a/src/components/Editor/PenHeader.vue
+++ b/src/components/Editor/PenHeader.vue
@@ -200,22 +200,22 @@
   }
 
   onMounted(async () => {
-  if (currentWork.value?.id !== undefined) {
-    const stored = favoritesStore.getFavorite(currentWork.value?.id);
-    if (stored.isLiked === undefined || stored.favoritesCount === undefined) {
-      await favoritesStore.fetchFavoriteState(currentWork.value?.id);
+    if (currentWork.value?.id !== undefined) {
+      const stored = favoritesStore.getFavorite(currentWork.value?.id);
+      if (stored.isLiked === undefined || stored.favoritesCount === undefined) {
+        await favoritesStore.fetchFavoriteState(currentWork.value?.id);
+      }
     }
-  }
-  });
+    });
   watch(
-  () => currentWork.value?.id,
-  (newVal) => {
-    if (newVal) {
-      favoritesStore.fetchFavoriteState(newVal);
-    }
-  },
-  { immediate: true }
-);
+    () => currentWork.value?.id,
+    (newVal) => {
+      if (newVal) {
+        favoritesStore.fetchFavoriteState(newVal);
+      }
+    },
+    { immediate: true }
+  );
 </script>
 
 <template>

--- a/src/components/PenCards/PenCard.vue
+++ b/src/components/PenCards/PenCard.vue
@@ -78,7 +78,7 @@
 
       <!-- 底部統計按鈕 -->
       <div class="flex gap-2 mt-3">
-        <FavoriteBtn :target-pen="workId" />
+        <PenFavoriteButton :target-pen="workId" />
         <PenCommentButton
           :work-id="workId"
           :comments="comments"
@@ -91,13 +91,13 @@
 </template>
 
 <script setup>
-import api from "@/config/api"; // API 請求配置
+import api from "@/config/api";
 import { ref, onMounted, computed } from "vue";
 import { useRouter } from "vue-router";
 import PenCardDropdown from "@/components/PenCards/PenCardDropdown.vue"; // 作品卡下拉選單元件
 
 import PenDetailsButton from "@/components/PenCards/PenDetailsButton.vue";
-import FavoriteBtn from "@/components/PenCards/PenFavoriteButton.vue";
+import PenFavoriteButton from "@/components/PenCards/PenFavoriteButton.vue";
 import PenCommentButton from "@/components/PenCards/PenCommentButton.vue";
 import PenViewButton from "@/components/PenCards/PenViewButton.vue";
 import { useModalStore } from "@/stores/useModalStore";
@@ -261,5 +261,4 @@ const openDetailModal = () => {
   modalStore.openModal(props.pen.id, "card");
 };
 
-// 需要改為用 store 管理收藏狀態，因為PenCard的收藏按鈕與Modal收藏按鈕狀態不同步
 </script>

--- a/src/components/PenCards/PenFavoriteButton.vue
+++ b/src/components/PenCards/PenFavoriteButton.vue
@@ -25,17 +25,15 @@ const router = useRouter();
 const msg = useMsgStore();
 const authStore = useAuthStore();
 const favoritesStore = useFavoritesStore();
-
+const favorite = computed(() => favoritesStore.getFavorite(props.targetPen));
+const isLiked = computed(() => favorite.value.isLiked);
+const favoritesCount = computed(() => favorite.value.favoritesCount);
 const props = defineProps({
   targetPen: {
     type: [String, Number],
     required: true,
   },
 });
-
-const favorite = computed(() => favoritesStore.getFavorite(props.targetPen));
-const isLiked = computed(() => favorite.value.isLiked);
-const favoritesCount = computed(() => favorite.value.favoritesCount);
 
 const handleClick = async () => {
   if (!authStore.user) {
@@ -60,6 +58,7 @@ const handleClick = async () => {
 };
 
 onMounted(async () => {
+  console.log("targetPen on mount", props.targetPen);
   if (props.targetPen !== undefined) {
     const stored = favoritesStore.getFavorite(props.targetPen);
     if (stored.isLiked === undefined || stored.favoritesCount === undefined) {

--- a/src/components/PenCards/PenFavoriteButton.vue
+++ b/src/components/PenCards/PenFavoriteButton.vue
@@ -58,7 +58,6 @@ const handleClick = async () => {
 };
 
 onMounted(async () => {
-  console.log("targetPen on mount", props.targetPen);
   if (props.targetPen !== undefined) {
     const stored = favoritesStore.getFavorite(props.targetPen);
     if (stored.isLiked === undefined || stored.favoritesCount === undefined) {

--- a/src/components/PenCards/PenFavoriteButton.vue
+++ b/src/components/PenCards/PenFavoriteButton.vue
@@ -25,15 +25,17 @@ const router = useRouter();
 const msg = useMsgStore();
 const authStore = useAuthStore();
 const favoritesStore = useFavoritesStore();
-const favorite = computed(() => favoritesStore.getFavorite(props.targetPen));
-const isLiked = computed(() => favorite.value.isLiked);
-const favoritesCount = computed(() => favorite.value.favoritesCount);
+
 const props = defineProps({
   targetPen: {
     type: [String, Number],
     required: true,
   },
 });
+
+const favorite = computed(() => favoritesStore.getFavorite(props.targetPen));
+const isLiked = computed(() => favorite.value.isLiked);
+const favoritesCount = computed(() => favorite.value.favoritesCount);
 
 const handleClick = async () => {
   if (!authStore.user) {
@@ -58,7 +60,6 @@ const handleClick = async () => {
 };
 
 onMounted(async () => {
-  console.log("targetPen on mount", props.targetPen);
   if (props.targetPen !== undefined) {
     const stored = favoritesStore.getFavorite(props.targetPen);
     if (stored.isLiked === undefined || stored.favoritesCount === undefined) {

--- a/src/components/PenDetails/PenContent.vue
+++ b/src/components/PenDetails/PenContent.vue
@@ -33,7 +33,7 @@ const props = defineProps({
     <aside class="meta-section lg:col-start-2 lg:row-span-3 space-y-4">
       <PenShareBox :pen-id="pen.id" :username="pen.username" />
       <PenTimestamps :pen="pen" />
-      <PenStats :likes="pen.favorites" :views="pen.views_count" />
+      <PenStats :pen="pen" :likes="pen.favorites"/>
     </aside>
   </div>
 </template>

--- a/src/components/PenDetails/PenContent.vue
+++ b/src/components/PenDetails/PenContent.vue
@@ -33,7 +33,7 @@ const props = defineProps({
     <aside class="meta-section lg:col-start-2 lg:row-span-3 space-y-4">
       <PenShareBox :pen-id="pen.id" :username="pen.username" />
       <PenTimestamps :pen="pen" />
-      <PenStats :pen="pen" :likes="pen.favorites"/>
+      <PenStats :pen="pen"/>
     </aside>
   </div>
 </template>

--- a/src/components/PenDetails/PenDetailModalHeader.vue
+++ b/src/components/PenDetails/PenDetailModalHeader.vue
@@ -72,9 +72,9 @@
 import { ref, onMounted, watch, onBeforeUnmount, computed } from "vue";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useModalStore } from "@/stores/useModalStore";
+import { useToastStore } from "@/stores/useToastStore";
 import { useFavoritesStore } from "@/stores/useFavoritesStore";
 import { useRouter, RouterLink } from "vue-router";
-import api from "@/config/api";
 import FollowBtn from "@/components/FollowBtn.vue";
 import ProTag from "@/components/Editor/ProTag.vue";
 import PenDetailDropdown from "@/components/PenDetails/PenDetailDropdown.vue";
@@ -90,6 +90,8 @@ const props = defineProps({
 const router = useRouter();
 const authStore = useAuthStore();
 const modalStore = useModalStore();
+const toastStore = useToastStore();
+const { showToast } = toastStore;
 
 const favoritesStore = useFavoritesStore()
 const favorite = computed(() => favoritesStore.getFavorite(props.pen.id));
@@ -105,9 +107,11 @@ const handleFavorite = async () => {
 
   try {
     await favoritesStore.toggleFavorite(props.pen.id);
-
   } catch (error) {
-    console.error("Favorite action failed:", error);
+    showToast({
+      message: "Action failed",
+      variant: "danger"
+    });
   }
 };
 
@@ -136,8 +140,6 @@ const goToEditor = () => {
 
 onMounted(async () => {
   document.addEventListener("click", handleClickOutside);
-
-    console.log("pen on mount", props.pen?.id);
   if (props.pen !== undefined) {
     const stored = favoritesStore.getFavorite(props.pen.id);
     if (stored.isLiked === undefined || stored.favoritesCount === undefined) {

--- a/src/components/PenDetails/PenDetailModalHeader.vue
+++ b/src/components/PenDetails/PenDetailModalHeader.vue
@@ -69,9 +69,10 @@
   </header>
 </template>
 <script setup>
-import { ref, onMounted, watch, onBeforeUnmount } from "vue";
+import { ref, onMounted, watch, onBeforeUnmount, computed } from "vue";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useModalStore } from "@/stores/useModalStore";
+import { useFavoritesStore } from "@/stores/useFavoritesStore";
 import { useRouter, RouterLink } from "vue-router";
 import api from "@/config/api";
 import FollowBtn from "@/components/FollowBtn.vue";
@@ -86,35 +87,25 @@ const props = defineProps({
   },
 });
 
+const router = useRouter();
 const authStore = useAuthStore();
 const modalStore = useModalStore();
-const router = useRouter();
-const isLiked = ref(false);
+
+const favoritesStore = useFavoritesStore()
+const favorite = computed(() => favoritesStore.getFavorite(props.pen.id));
+const isLiked = computed(() => favorite.value.isLiked);
 const isDropdownOpen = ref(false);
 const dropdownRef = ref(null);
 
-const checkFavorite = async () => {
-  if (!authStore.userProfile) return;
-  const res = await api.get(`/api/favorites/check/${props.pen.id}/`);
-  isLiked.value = res.data.liked;
-};
-
 const handleFavorite = async () => {
-  if (!authStore.userProfile) {
+  if (!authStore.user) {
     modalStore.closeModal();
     return router.push("/login");
   }
 
   try {
-    if (!isLiked.value) {
-      await api.post(`/api/favorites/`, { pen_id: props.pen.id });
-      isLiked.value = true;
-    } else {
-      await api.delete(`/api/favorites/`, {
-        data: { pen_id: props.pen.id },
-      });
-      isLiked.value = false;
-    }
+    await favoritesStore.toggleFavorite(props.pen.id);
+
   } catch (error) {
     console.error("Favorite action failed:", error);
   }
@@ -143,8 +134,16 @@ const goToEditor = () => {
   router.push(`/${props.pen.username}/dose/${props.pen.id}`);
 };
 
-onMounted(() => {
+onMounted(async () => {
   document.addEventListener("click", handleClickOutside);
+
+    console.log("pen on mount", props.pen?.id);
+  if (props.pen !== undefined) {
+    const stored = favoritesStore.getFavorite(props.pen.id);
+    if (stored.isLiked === undefined || stored.favoritesCount === undefined) {
+      await favoritesStore.fetchFavoriteState(props.pen.id);
+    }
+  }
 });
 onBeforeUnmount(() => {
   document.removeEventListener("click", handleClickOutside);
@@ -153,8 +152,8 @@ onBeforeUnmount(() => {
 watch(
   () => props.pen,
   (newPen) => {
-    if (newPen && authStore.userProfile) {
-      checkFavorite();
+    if (newPen && authStore.user) {
+      favoritesStore.fetchFavoriteState(newPen.id);
     }
   },
   { immediate: true }

--- a/src/components/PenDetails/PenShareBox.vue
+++ b/src/components/PenDetails/PenShareBox.vue
@@ -18,7 +18,6 @@
 <script setup>
 import { useToastStore } from "@/stores/useToastStore";
 const toastStore = useToastStore();
-console.log(toastStore);
 
 const props = defineProps({
   penId: {

--- a/src/components/PenDetails/PenStats.vue
+++ b/src/components/PenDetails/PenStats.vue
@@ -46,28 +46,54 @@
     <div class="mb-4 clear-both">
       <h3 class="text-cc-7 text-base mb-2 flex items-center">
         <EyeIcon class="w-4 h-4 fill-current mr-1" />
-        <span class="font-bold mr-1">{{ views }}</span> Views
+        <span class="font-bold mr-1">{{ pen.favoritesCount }}</span> Views
       </h3>
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from "vue";
+import api from "@/config/api.js"
+import { ref, computed, watch } from "vue";
+import { useFavoritesStore } from "@/stores/useFavoritesStore";
 import HeartIcon from "@/components/icons/HeartIcon.vue";
 import EyeIcon from "@/components/icons/EyeIcon.vue";
 
+const favoritesStore = useFavoritesStore();
 const props = defineProps({
+  pen: {
+    type: Object,
+    required: true
+  },
   likes: {
     type: Array,
     default: () => [], // [{ id, username, display_name, profile_image_url }]
   },
-  views: {
-    type: Number,
-    default: 0,
-  },
 });
 
 const maxVisible = 6;
-const visibleLikes = computed(() => props.likes.slice(0, maxVisible));
+const likes = ref(props.likes)
+const visibleLikes = computed(() => likes.value.slice(0, maxVisible));
+
+async function fetchLikes() {
+  try {
+    const res = await api.get(`/api/pens/${props.pen.id}`);
+    console.log(res.data.favorites);
+    likes.value = res.data.favorites;
+  } catch (err) {
+    console.error("Failed to fetch likes", err);
+  }
+}
+
+
+watch(
+  () => favoritesStore.getFavorite(props.pen.id)?.isLiked,
+  async (newVal, oldVal) => {
+    console.log(newVal, oldVal);
+    if (newVal !== oldVal) {
+      await fetchLikes();
+    }
+  }
+);
+
 </script>

--- a/src/components/PenDetails/PenStats.vue
+++ b/src/components/PenDetails/PenStats.vue
@@ -56,10 +56,13 @@
 import api from "@/config/api.js"
 import { ref, computed, watch } from "vue";
 import { useFavoritesStore } from "@/stores/useFavoritesStore";
+import { useToastStore } from "@/stores/useToastStore";
 import HeartIcon from "@/components/icons/HeartIcon.vue";
 import EyeIcon from "@/components/icons/EyeIcon.vue";
 
 const favoritesStore = useFavoritesStore();
+const toastStore = useToastStore();
+const { showToast } = toastStore;
 const props = defineProps({
   pen: {
     type: Object,
@@ -78,9 +81,12 @@ const visibleLikes = computed(() => likes.value.slice(0, maxVisible));
 async function fetchLikes() {
   try {
     const res = await api.get(`/api/pens/${props.pen.id}`);
-    console.log(res.data.favorites);
     likes.value = res.data.favorites;
   } catch (err) {
+    showToast({
+      message: "Failed to fetch likes",
+      variant: "danger"
+    })
     console.error("Failed to fetch likes", err);
   }
 }
@@ -89,7 +95,6 @@ async function fetchLikes() {
 watch(
   () => favoritesStore.getFavorite(props.pen.id)?.isLiked,
   async (newVal, oldVal) => {
-    console.log(newVal, oldVal);
     if (newVal !== oldVal) {
       await fetchLikes();
     }

--- a/src/components/PenDetails/PenStats.vue
+++ b/src/components/PenDetails/PenStats.vue
@@ -68,14 +68,10 @@ const props = defineProps({
     type: Object,
     required: true
   },
-  likes: {
-    type: Array,
-    default: () => [], // [{ id, username, display_name, profile_image_url }]
-  },
 });
 
 const maxVisible = 6;
-const likes = ref(props.likes)
+const likes = ref(props.pen.favorites)
 const visibleLikes = computed(() => likes.value.slice(0, maxVisible));
 
 async function fetchLikes() {

--- a/src/stores/useFavoritesStore.js
+++ b/src/stores/useFavoritesStore.js
@@ -22,9 +22,7 @@ export const useFavoritesStore = defineStore("favorites", () => {
     if(authStore.user){
     likedRes = await checkFavoriteAPI(penId);
     }
-    const countRes = await countFavoritesAPI(penId);
-    console.log("fetchFavoriteState資料",likedRes?.data, countRes.data);
-    const newState = {
+    const countRes = await countFavoritesAPI(penId);    const newState = {
       isLiked: likedRes?.data?.liked || false,
       favoritesCount: countRes.data.favoritesCount ?? 0,
     };

--- a/src/stores/useFavoritesStore.js
+++ b/src/stores/useFavoritesStore.js
@@ -1,7 +1,9 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
+import { useAuthStore } from "@/stores/useAuthStore";
 import { addFavoriteAPI, removeFavoriteAPI, checkFavoriteAPI, countFavoritesAPI } from "@/api/favorites";
 
+const authStore = useAuthStore();
 export const useFavoritesStore = defineStore("favorites", () => {
   const favoritesMap = ref(new Map());
 
@@ -16,11 +18,14 @@ export const useFavoritesStore = defineStore("favorites", () => {
 
   async function fetchFavoriteState(penId) {
   try {
-    const likedRes = await checkFavoriteAPI(penId);
+    let likedRes;
+    if(authStore.user){
+    likedRes = await checkFavoriteAPI(penId);
+    }
     const countRes = await countFavoritesAPI(penId);
-    console.log("fetchFavoriteState資料",likedRes.data, countRes.data);
+    console.log("fetchFavoriteState資料",likedRes?.data, countRes.data);
     const newState = {
-      isLiked: likedRes.data.liked,
+      isLiked: likedRes?.data?.liked || false,
       favoritesCount: countRes.data.favoritesCount ?? 0,
     };
     favoritesMap.value.set(penId, newState);

--- a/src/stores/useFavoritesStore.js
+++ b/src/stores/useFavoritesStore.js
@@ -1,54 +1,75 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import { addFavoriteAPI, removeFavoriteAPI, checkFavoriteAPI, countFavoritesAPI } from "@/api/favorites";
+import {
+  addFavoriteAPI,
+  removeFavoriteAPI,
+  checkFavoriteAPI,
+  countFavoritesAPI,
+} from "@/api/favorites";
 
 export const useFavoritesStore = defineStore("favorites", () => {
   const favoritesMap = ref(new Map());
 
   function setFavorite(penId, isLiked, favoritesCount) {
-    favoritesMap.value.set(penId, { isLiked, favoritesCount });
-    return favoritesMap.value.get(penId);
+    let stateRef = favoritesMap.value.get(penId);
+
+    if (!stateRef) {
+      stateRef = ref({ isLiked, favoritesCount });
+      favoritesMap.value.set(penId, stateRef);
+    } else {
+      stateRef.isLiked = isLiked;
+      stateRef.favoritesCount = favoritesCount;
+    }
+
+    return stateRef;
   }
 
   function getFavorite(penId) {
-    return favoritesMap.value.get(penId) || { isLiked: false, favoritesCount: 0 };
+    let stateRef = favoritesMap.value.get(penId);
+
+    if (!stateRef) {
+      stateRef = ref({ isLiked: false, favoritesCount: 0 });
+      favoritesMap.value.set(penId, stateRef);
+      fetchFavoriteState(penId).catch((err) =>
+        console.error("Failed to fetch favorite state", err)
+      );
+    }
+
+    return stateRef;
   }
 
   async function fetchFavoriteState(penId) {
-  try {
-    const likedRes = await checkFavoriteAPI(penId);
-    const countRes = await countFavoritesAPI(penId);
-    console.log("fetchFavoriteState資料",likedRes.data, countRes.data);
-    const newState = {
-      isLiked: likedRes.data.liked,
-      favoritesCount: countRes.data.favoritesCount ?? 0,
-    };
-    favoritesMap.value.set(penId, newState);
-    return newState;
-  } catch (err) {
-    console.error("Failed to fetch favorite state for pen:", penId, err);
-    return { isLiked: false, favoritesCount: 0 };
+    try {
+      const likedRes = await checkFavoriteAPI(penId);
+      const countRes = await countFavoritesAPI(penId);
+      const newState = ref({
+        isLiked: likedRes.data.liked,
+        favoritesCount: countRes.data.favoritesCount ?? 0,
+      });
+      favoritesMap.value.set(penId, newState);
+      return newState;
+    } catch (err) {
+      console.error("Failed to fetch favorite state for pen:", penId, err);
+      return { isLiked: false, favoritesCount: 0 };
+    }
   }
-}
 
   async function toggleFavorite(penId) {
     const current = getFavorite(penId);
-    const newState = { ...current };
 
     if (current.isLiked) {
       await removeFavoriteAPI(penId);
-      newState.isLiked = false;
-      newState.favoritesCount--;
+      current.isLiked = false;
+      current.favoritesCount--;
     } else {
       await addFavoriteAPI(penId);
-      newState.isLiked = true;
-      newState.favoritesCount++;
+      current.isLiked = true;
+      current.favoritesCount++;
     }
-
-    favoritesMap.value.set(penId, newState);
   }
 
   return {
+    favoritesMap,
     setFavorite,
     getFavorite,
     fetchFavoriteState,

--- a/src/stores/useFavoritesStore.js
+++ b/src/stores/useFavoritesStore.js
@@ -1,0 +1,116 @@
+import { ref } from "vue";
+import { defineStore } from "pinia";
+import {
+  addFavoriteAPI,
+  removeFavoriteAPI,
+  checkFavoriteAPI,
+  countFavoritesAPI,
+  initDoses,
+} from "@/api/favorites.js";
+
+export const useFavoriteStore = defineStore("favorites", () => {
+  const doses = ref(new Map());
+
+  function setDose(dose) {
+    doses.value.set(dose.id, dose);
+  }
+
+  function setDoses(doseList) {
+    doseList.forEach((dose) => doses.value.set(dose.id, dose));
+  }
+
+  function getDose(id) {
+    return doses.value.get(id);
+  }
+
+  async function fetchFavoritesState() {
+    try {
+      const res = await checkFavoriteAPI(doseId);
+      const dose = doses.value.get(doseId);
+      if (dose) {
+        dose.isLiked = res.data.liked;
+        doses.value.set(doseId, { ...dose });
+      }
+    } catch (err) {
+      console.error("Fail to fetch favorites state", err);
+    }
+  }
+  async function fetchFavoritesCount(doseId) {
+    try {
+      const res = await countFavoritesAPI(doseId);
+      const dose = DisposableStack.value.get(doseId);
+      if (dose) {
+        dose.favoritesCount = res.data.favoritesCount;
+        doses.value.set(doseId, { ...dose });
+      }
+    } catch (err) {
+      console.error("Fail to fetch favorites count", err);
+    }
+  }
+  async function initDoseState(doseId) {
+    const dose = doses.value.get(doseId);
+    if (!dose || doses.isInitialized) return;
+
+    try {
+      await Promise.all([
+        fetchFavoritesState(doseId),
+        fetchFavoritesCount(doseId),
+      ]);
+      doses.value.set(doseId, {
+        ...doses.value.get(doseId),
+        isInitialized: true,
+      });
+    } catch (err) {
+      console.error("Fail to initialize doses state")
+    }
+  }
+  async function toggleFavorite(doseId) {
+    const dose = doses.value.get(doseId);
+    if (!dose) return;
+
+    try {
+      if (dose.isLiked) {
+        await removeFavoriteAPI(doseId);
+        dose.isLiked = false;
+        dose.favoritesCount--;
+      } else {
+        await addFavoriteAPI(doseId);
+        dose.isLiked = true;
+        dose.favoritesCount++;
+      }
+      doses.value.set(doseId, { ...dose });
+    } catch (err) {
+      console.error("Fail to toggle favorites", err);
+    }
+  }
+
+  async function initDoseState(doseId) {
+    await Promise.all([
+      fetchFavoritesState(doseId),
+      fetchFavoritesCount(doseId),
+    ]);
+  }
+
+  function clearDoses() {
+    doses.value.clear();
+  }
+
+  function resetInitialization(id) {
+    const dose = doses.value.get(id);
+    if (dose) {
+      dose.isInitialized = false;
+      doses.value.set(id, { ...dose });
+    }
+  }
+
+  return {
+    doses,
+    setDose,
+    setDoses,
+    getDose,
+    toggleFavorite,
+    fetchFavoritesState,
+    fetchFavoritesCount,
+    initDoseState,
+  };
+});

--- a/src/views/YourWork.vue
+++ b/src/views/YourWork.vue
@@ -327,8 +327,10 @@ import TagsIcon from "@/components/icons/TagsIcon.vue";
 import DescIcon from "@/components/icons/DescIcon.vue";
 import AscIcon from "@/components/icons/AscIcon.vue";
 import { useToastStore } from "@/stores/useToastStore";
+import { useFavoritesStore } from "@/stores/useFavoritesStore";
 
 const toastStore = useToastStore();
+const favoritesStore = useFavoritesStore();
 const router = useRouter();
 const { showToast } = toastStore;
 // data
@@ -452,6 +454,10 @@ async function loadDoses() {
       },
     });
 
+    data.results.forEach((pen) => {
+      favoritesStore.setFavorite(pen.id, pen.is_liked, pen.favorites_count);
+    });
+
     pens.value = data.results;
     total.value = data.total;
     totalPages.value = data.totalPages;
@@ -541,12 +547,4 @@ async function restoreDose(penId) {
     });
   }
 }
-
-/**
- * TODO:
- * 頁面載入中狀態
- * 加上 toast 通知
- * 加上錯誤處理
- * 這頁太長了需要考慮拆分元件
- */
 </script>

--- a/src/views/YourWork.vue
+++ b/src/views/YourWork.vue
@@ -454,10 +454,6 @@ async function loadDoses() {
       },
     });
 
-    data.results.forEach((pen) => {
-      favoritesStore.setFavorite(pen.id, pen.is_liked, pen.favorites_count);
-    });
-
     pens.value = data.results;
     total.value = data.total;
     totalPages.value = data.totalPages;


### PR DESCRIPTION
close #261
1. 將作品收藏狀態改為使用 pinia 做全域管理
2. 新增 `api` 資料夾專門存放呼叫API的方法 (目前只放了favorites.js) 

### 效果展示

https://github.com/user-attachments/assets/597c47a5-f53a-45a2-9c2e-0f81180e45ab

