### PR TITLE
[fix] PenDetailModal 加上 v-if="pen" 等 API 取得資料後再進行 UI 渲染與 props 傳值

### DIFF
--- a/src/components/PenDetails/PenDetailModal.vue
+++ b/src/components/PenDetails/PenDetailModal.vue
@@ -4,12 +4,13 @@
     class="fixed inset-0 bg-black/40 z-50 text-cc-20 overflow-auto"
   >
     <div
+      v-if="pen"
       @click.stop
       class="mx-auto mt-16 mb-10 w-[90%] max-w-[800px] bg-cc-16 rounded-lg shadow-lg relative"
     >
-      <PenDetailModalHeader v-if="from === 'card'" :pen="pen" />
+      <PenDetailModalHeader v-if="from === 'card' && pen" :pen="pen" />
       <!-- iframe 預覽 -->
-      <PenDetailPreviewIframe v-if="from === 'card'" :pen="pen" />
+      <PenDetailPreviewIframe v-if="from === 'card' && pen" :pen="pen" />
 
       <PenDetailContent v-if="pen" :pen="pen" @close="close" />
     </div>


### PR DESCRIPTION
close #289 
#289 的錯誤訊息來自於 Vue 的 props 傳遞是同步的，但上層的 PenDetailModal 打API取得Pen資料是非同步行為，在還未取得Pen回傳資料就掛載Header導致Props.pen一開始的值是null

解決方式是在Modal加上 v-if="pen"，等pen得到回傳值後再進行元件渲染