### PR TITLE
[fix] 修正 Following 頁版面與 Trending 頁 PenCard 刪除與更改權限後的 UI 更新

### DIFF
--- a/src/views/Following.vue
+++ b/src/views/Following.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="px-6 py-4 relative group">
+  <section class="px-6 py-4 relative">
     <!-- Toggle Switch -->
     <div class="max-w-[1140px] mx-auto mb-6">
       <div
@@ -30,74 +30,103 @@
     >
       You're not following anyone yet.
     </p>
-    <!-- 卡片輪播 Swiper -->
-    <Swiper
-      :modules="[Navigation]"
-      :observer="true"
-      :observe-parents="true"
-      :slides-per-view="1"
-      :space-between="30"
-      :navigation="{ nextEl: '.swiper-next', prevEl: '.swiper-prev' }"
-      @slideChange="handleSlideChange"
-      @swiper="onSwiperInit"
-      class="w-full max-w-[1140px] mx-auto"
-    >
-      <SwiperSlide
-        v-for="(group, index) in chunkedCards"
-        :key="'group-' + index"
+    <div class="relative group">
+      <!-- 卡片輪播 Swiper -->
+      <Swiper
+        :modules="[Navigation]"
+        :observer="true"
+        :observe-parents="true"
+        :slides-per-view="1"
+        :space-between="30"
+        :navigation="{ nextEl: '.swiper-next', prevEl: '.swiper-prev' }"
+        @slideChange="handleSlideChange"
+        @swiper="onSwiperInit"
+        class="w-full max-w-[1140px] mx-auto"
       >
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <PenCard
-            v-for="pen in group"
-            :key="pen.id"
-            :pen="pen"
-            @delete="handleDeletePen"
-            @privacy-changed="handlePrivacyChanged"
-          />
+        <SwiperSlide
+          v-for="(group, index) in chunkedCards"
+          :key="'group-' + index"
+        >
+          <div
+            class="grid grid-cols-1 sm:grid-cols-2 max-w-[500px] sm:max-w-none gap-6 w-8/9 mx-auto"
+          >
+            <PenCard v-for="pen in group" :key="pen.id" :pen="pen" />
+          </div>
+        </SwiperSlide>
+      </Swiper>
+
+      <!-- 左右箭頭 -->
+      <button
+        class="h-full swiper-prev hidden relative sm:flex sm:absolute inset-y-0 left-0 z-[11] items-center justify-start group/swiper-prev"
+      >
+        <div
+          class="sm:w-[38px] sm:h-[70px] -ml-2 relative z-10 w-[70px] h-[38px] rounded bg-[#2c2c2c] hover:bg-green-800 transition-colors flex items-center justify-center ring-0 group-hover/swiper-prev:ring-2 group-hover/swiper-prev:ring-white"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-5 h-5 text-white"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M15 19l-7-7 7-7" />
+          </svg>
         </div>
-      </SwiperSlide>
-    </Swiper>
+      </button>
 
-    <!-- 左右箭頭 -->
-    <button
-      class="swiper-prev absolute inset-y-0 left-0 z-[11] w-[90px] flex items-center justify-start group"
-    >
-      <div
-        class="relative z-10 ml-3 w-[38px] h-[70px] rounded bg-cc-14 hover:bg-cc-green-dark transition-colors flex items-center justify-center ring-0 group-hover:ring-2 group-hover:ring-white"
+      <button
+        class="h-full swiper-next hidden relative sm:flex sm:absolute inset-y-0 right-0 z-[11] flex items-center justify-end group/swiper-next"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="w-5 h-5 text-white"
-          fill="currentColor"
-          viewBox="0 0 24 24"
+        <div
+          class="relative w-[70px] h-[38px] -mr-2 z-10 sm:w-[38px] sm:h-[70px] rounded bg-[#2c2c2c] hover:bg-green-800 transition-colors flex items-center justify-center ring-0 group-hover/swiper-next:ring-2 group-hover/swiper-next:ring-white"
         >
-          <path d="M15 19l-7-7 7-7" />
-        </svg>
-      </div>
-      <span
-        class="absolute inset-0 bg-gradient-to-r from-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"
-      ></span>
-    </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-5 h-5 text-white"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+      </button>
+      <div class="flex sm:hidden justify-center mt-4 gap-4">
+        <!-- Prev Button -->
+        <button
+          class="swiper-prev inline-block relative sm:flex sm:absolute inset-y-0 left-0 z-[11] items-center justify-start group"
+        >
+          <div
+            class="sm:w-[38px] sm:h-[70px] relative z-10 ml-3 w-[70px] h-[38px] rounded bg-[#2c2c2c] hover:bg-green-800 transition-colors flex items-center justify-center ring-0 group-hover:ring-2 group-hover:ring-white"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-5 h-5 text-white"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M15 19l-7-7 7-7" />
+            </svg>
+          </div>
+        </button>
 
-    <button
-      class="swiper-next absolute inset-y-0 right-0 z-[11] w-[90px] flex items-center justify-end group"
-    >
-      <div
-        class="relative z-10 mr-3 w-[38px] h-[70px] rounded bg-cc-14 hover:bg-cc-green-dark transition-colors flex items-center justify-center ring-0 group-hover:ring-2 group-hover:ring-white"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="w-5 h-5 text-white"
-          fill="currentColor"
-          viewBox="0 0 24 24"
+        <!-- Next Button -->
+        <button
+          class="swiper-next inline-block relative sm:flex sm:absolute inset-y-0 right-0 z-[11] flex items-center justify-end group"
         >
-          <path d="M9 5l7 7-7 7" />
-        </svg>
+          <div
+            class="relative w-[70px] h-[38px] z-10 mr-3 sm:w-[38px] sm:h-[70px] rounded bg-[#2c2c2c] hover:bg-green-800 transition-colors flex items-center justify-center ring-0 group-hover:ring-2 group-hover:ring-white"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-5 h-5 text-white"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M9 5l7 7-7 7" />
+            </svg>
+          </div>
+        </button>
       </div>
-      <span
-        class="absolute inset-0 bg-gradient-to-l from-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"
-      ></span>
-    </button>
+    </div>
   </section>
 </template>
 

--- a/src/views/Trending.vue
+++ b/src/views/Trending.vue
@@ -24,8 +24,8 @@
               v-for="pen in group"
               :key="pen.id"
               :pen="pen"
-              @delete="handleDeletePen"
-              @privacy-changed="handlePrivacyChanged"
+              @delete="reloadTrending"
+              @privacy-changed="reloadTrending"
             />
           </div>
         </SwiperSlide>
@@ -108,7 +108,7 @@
 
 <script setup>
 import { nextTick } from "vue";
-import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { Swiper, SwiperSlide } from "swiper/vue";
 import { Navigation } from "swiper/modules";
 import { useToastStore } from "@/stores/useToastStore";


### PR DESCRIPTION
1. Following 頁的版面修改為與 Trending 頁一致
![image](https://github.com/user-attachments/assets/78fd6825-224d-4105-b84e-5f0a8d80e287)
2. Trending 頁的 PenCard 刪除與更改權限後的事件處理修復為 reloadTrending()
![image](https://github.com/user-attachments/assets/dfb00db5-1551-4713-97b9-0e0043e820ba)
3. 刪除與更改權限過程示範影片：

https://github.com/user-attachments/assets/47e4025e-e355-46de-91a3-cc080af0afa9

