### PR TITLE
[style] 修改 editor 頁面 title 顯示過長

### DIFF
--- a/src/components/Editor/PenHeader.vue
+++ b/src/components/Editor/PenHeader.vue
@@ -232,11 +232,11 @@
               v-model="title"
               @blur="stopEdit"
               @keyup.enter="stopEdit"
-              class="h-3 md:h-5 bg-transparent text-white font-black text-sm md:text-lg leading-none outline-none w-full appearance-none"
+              class="bg-transparent text-white font-black text-sm md:text-lg leading-tight outline-none w-full appearance-none"
             />
           </template>
           <template v-else>
-            <span class="h-3 md:h-5 text-white font-black text-sm md:text-lg leading-none overflow-hidden text-ellipsis whitespace-nowrap">
+            <span class="inline-block text-white font-black text-sm md:text-lg leading-tight overflow-hidden text-ellipsis whitespace-nowrap max-w-[160px] md:max-w-[280px]">
               {{ title.length ? title : "Untitled" }}
             </span>
           </template>

--- a/src/views/Pen.vue
+++ b/src/views/Pen.vue
@@ -527,7 +527,7 @@
     </template>
   </ConfirmModal>
   <ToastContainer />
-  <div class="flex flex-col h-dvh">
+  <div class="flex flex-col h-dvh overflow-hidden">
     <AnonLoginModal/>
     <AIChatButton ref="aiChatButtonRef" @handleOpenAIChat = "handleOpenAIChat" v-if="isPro"/>
     <PenHeader @run-preview="handleRunPreview" :currentWork = "currentWork" ref="penHeader"/>


### PR DESCRIPTION
原：
<img width="385" alt="截圖 2025-07-02 14 54 05" src="https://github.com/user-attachments/assets/8003d2ec-975c-4e8e-8409-a25f21370462" />

調整後：
<img width="384" alt="截圖 2025-07-02 14 52 45" src="https://github.com/user-attachments/assets/4539f9a3-af95-4c5b-a440-aac061aee62c" />
